### PR TITLE
Load validator rules asynchronously

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,6 +2,79 @@
   "version": "0.2.0",
   "configurations": [
     {
+      "name": "Launch batchfossilizer test function",
+      "type": "go",
+      "request": "launch",
+      "mode": "test",
+      "program": "${workspaceRoot}/batchfossilizer",
+      "env": {},
+      "args": []
+    },
+
+    {
+      "name": "Launch bcbatchfossilizer test function",
+      "type": "go",
+      "request": "launch",
+      "mode": "test",
+      "program": "${workspaceRoot}/bcbatchfossilizer",
+      "env": {},
+      "args": []
+    },
+    {
+      "name": "Launch blockchain test function",
+      "type": "go",
+      "request": "launch",
+      "mode": "test",
+      "program": "${workspaceRoot}/blockchain",
+      "env": {},
+      "args": []
+    },
+    {
+      "name": "Launch blockchain/btc test function",
+      "type": "go",
+      "request": "launch",
+      "mode": "test",
+      "program": "${workspaceRoot}/blockchain/btc",
+      "env": {},
+      "args": []
+    },
+    {
+      "name": "Launch blockchain/btc/blockcypher test function",
+      "type": "go",
+      "request": "launch",
+      "mode": "test",
+      "program": "${workspaceRoot}/blockchain/btc/blockcypher",
+      "env": {},
+      "args": []
+    },
+    {
+      "name": "Launch blockchain/btc/btctesting test function",
+      "type": "go",
+      "request": "launch",
+      "mode": "test",
+      "program": "${workspaceRoot}/blockchain/btc/btctesting",
+      "env": {},
+      "args": []
+    },
+    {
+      "name": "Launch blockchain/btc/btctimestamper test function",
+      "type": "go",
+      "request": "launch",
+      "mode": "test",
+      "program": "${workspaceRoot}/blockchain/btc/btctimestamper",
+      "env": {},
+      "args": []
+    },
+    {
+      "name": "Launch blockchain/dummytimestamper test function",
+      "type": "go",
+      "request": "launch",
+      "mode": "test",
+      "program": "${workspaceRoot}/blockchain/dummytimestamper",
+      "env": {},
+      "args": []
+    },
+    {
       "name": "Launch bufferedbatch test function",
       "type": "go",
       "request": "launch",
@@ -92,6 +165,33 @@
       "args": []
     },
     {
+      "name": "Launch merkle test function",
+      "type": "go",
+      "request": "launch",
+      "mode": "test",
+      "program": "${workspaceRoot}/merkle",
+      "env": {},
+      "args": []
+    },
+    {
+      "name": "Launch postgresstore test function",
+      "type": "go",
+      "request": "launch",
+      "mode": "test",
+      "program": "${workspaceRoot}/postgresstore",
+      "env": {},
+      "args": []
+    },
+    {
+      "name": "Launch rethinkstore test function",
+      "type": "go",
+      "request": "launch",
+      "mode": "test",
+      "program": "${workspaceRoot}/rethinkstore",
+      "env": {},
+      "args": []
+    },
+    {
       "name": "Launch store test function",
       "type": "go",
       "request": "launch",
@@ -135,6 +235,32 @@
       "program": "${workspaceRoot}/tmpop",
       "env": {},
       "args": ["-test.run", "TestQuery/Evidence"]
+    },
+    {
+      "name": "btcfossilizer debug",
+      "type": "go",
+      "request": "launch",
+      "mode": "debug",
+      "remotePath": "",
+      "port": 2345,
+      "host": "127.0.0.1",
+      "program": "${workspaceRoot}/cmd/btcfossilizer",
+      "env": {},
+      "args": ["-wif", "924v2d7ryXJjnbwB6M9GsZDEjAkfE9aHeQAG1j8muA4UEjozeAJ"],
+      "showLog": true
+    },
+    {
+      "name": "dummybatchfossilizer debug",
+      "type": "go",
+      "request": "launch",
+      "mode": "debug",
+      "remotePath": "",
+      "port": 2345,
+      "host": "127.0.0.1",
+      "program": "${workspaceRoot}/cmd/dummybatchfossilizer",
+      "env": {},
+      "args": [],
+      "showLog": true
     },
     {
       "name": "dummyfossilizer debug",
@@ -212,132 +338,6 @@
       "args": []
     },
     {
-      "name": "Launch batchfossilizer test function",
-      "type": "go",
-      "request": "launch",
-      "mode": "test",
-      "program": "${workspaceRoot}/batchfossilizer",
-      "env": {},
-      "args": []
-    },
-
-    {
-      "name": "Launch bcbatchfossilizer test function",
-      "type": "go",
-      "request": "launch",
-      "mode": "test",
-      "program": "${workspaceRoot}/bcbatchfossilizer",
-      "env": {},
-      "args": []
-    },
-    {
-      "name": "Launch blockchain test function",
-      "type": "go",
-      "request": "launch",
-      "mode": "test",
-      "program": "${workspaceRoot}/blockchain",
-      "env": {},
-      "args": []
-    },
-    {
-      "name": "Launch blockchain/btc test function",
-      "type": "go",
-      "request": "launch",
-      "mode": "test",
-      "program": "${workspaceRoot}/blockchain/btc",
-      "env": {},
-      "args": []
-    },
-    {
-      "name": "Launch blockchain/btc/blockcypher test function",
-      "type": "go",
-      "request": "launch",
-      "mode": "test",
-      "program": "${workspaceRoot}/blockchain/btc/blockcypher",
-      "env": {},
-      "args": []
-    },
-    {
-      "name": "Launch blockchain/btc/btctesting test function",
-      "type": "go",
-      "request": "launch",
-      "mode": "test",
-      "program": "${workspaceRoot}/blockchain/btc/btctesting",
-      "env": {},
-      "args": []
-    },
-    {
-      "name": "Launch blockchain/btc/btctimestamper test function",
-      "type": "go",
-      "request": "launch",
-      "mode": "test",
-      "program": "${workspaceRoot}/blockchain/btc/btctimestamper",
-      "env": {},
-      "args": []
-    },
-    {
-      "name": "Launch blockchain/dummytimestamper test function",
-      "type": "go",
-      "request": "launch",
-      "mode": "test",
-      "program": "${workspaceRoot}/blockchain/dummytimestamper",
-      "env": {},
-      "args": []
-    },
-    {
-      "name": "Launch merkle test function",
-      "type": "go",
-      "request": "launch",
-      "mode": "test",
-      "program": "${workspaceRoot}/merkle",
-      "env": {},
-      "args": []
-    },
-    {
-      "name": "Launch postgresstore test function",
-      "type": "go",
-      "request": "launch",
-      "mode": "test",
-      "program": "${workspaceRoot}/postgresstore",
-      "env": {},
-      "args": []
-    },
-    {
-      "name": "Launch rethinkstore test function",
-      "type": "go",
-      "request": "launch",
-      "mode": "test",
-      "program": "${workspaceRoot}/rethinkstore",
-      "env": {},
-      "args": []
-    },
-    {
-      "name": "btcfossilizer debug",
-      "type": "go",
-      "request": "launch",
-      "mode": "debug",
-      "remotePath": "",
-      "port": 2345,
-      "host": "127.0.0.1",
-      "program": "${workspaceRoot}/cmd/btcfossilizer",
-      "env": {},
-      "args": ["-wif", "924v2d7ryXJjnbwB6M9GsZDEjAkfE9aHeQAG1j8muA4UEjozeAJ"],
-      "showLog": true
-    },
-    {
-      "name": "dummybatchfossilizer debug",
-      "type": "go",
-      "request": "launch",
-      "mode": "debug",
-      "remotePath": "",
-      "port": 2345,
-      "host": "127.0.0.1",
-      "program": "${workspaceRoot}/cmd/dummybatchfossilizer",
-      "env": {},
-      "args": [],
-      "showLog": true
-    },
-    {
       "name": "postgresstore debug",
       "type": "go",
       "request": "launch",
@@ -346,6 +346,22 @@
       "port": 2345,
       "host": "127.0.0.1",
       "program": "${workspaceRoot}/cmd/postgresstore",
+      "env": {},
+      "args": [
+        "-url",
+        "postgres://postgres@localhost/postgres?sslmode=disable"
+      ],
+      "showLog": true
+    },
+    {
+      "name": "postgrestmpop debug",
+      "type": "go",
+      "request": "launch",
+      "mode": "debug",
+      "remotePath": "",
+      "port": 2345,
+      "host": "127.0.0.1",
+      "program": "${workspaceRoot}/cmd/postgrestmpop",
       "env": {},
       "args": [
         "-url",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -703,6 +703,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "6d9f4e071c2f9bbc9a5449e51be90614f4ca71c0c6ddce2f25ba5bc2ed58de58"
+  inputs-digest = "22d02797da1927b07f7a8bbdbec79fd46dc2450303b1d5657e8104e7ecb4d68e"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/tmpop/state.go
+++ b/tmpop/state.go
@@ -18,6 +18,10 @@ import (
 	"crypto/sha256"
 	"fmt"
 
+	"github.com/fsnotify/fsnotify"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+
 	"github.com/stratumn/go-indigocore/bufferedbatch"
 	"github.com/stratumn/go-indigocore/cs"
 	"github.com/stratumn/go-indigocore/merkle"
@@ -39,10 +43,13 @@ type State struct {
 	deliveredLinks     store.Batch
 	deliveredLinksList []*cs.Link
 	checkedLinks       store.Batch
+
+	validatorWatcher *fsnotify.Watcher
+	validatorChan    chan validator.Validator
 }
 
 // NewState creates a new State.
-func NewState(a store.Adapter) (*State, error) {
+func NewState(a store.Adapter, config *Config) (*State, error) {
 	deliveredLinks, err := a.NewBatch()
 	if err != nil {
 		return nil, err
@@ -52,11 +59,65 @@ func NewState(a store.Adapter) (*State, error) {
 	// (more exactly, checked links would lock out delivered links)
 	checkedLinks := bufferedbatch.NewBatch(a)
 
+	var validatorChan = make(chan validator.Validator, 1)
+	var watcher *fsnotify.Watcher
+
+	if config.ValidatorFilename != "" {
+		loadValidatorFile(config.ValidatorFilename, validatorChan)
+		var err error
+		if watcher, err = fsnotify.NewWatcher(); err != nil {
+			return nil, errors.Wrap(err, "cannot create a new filesystem watcher for validators")
+		}
+		if err = watcher.Add(config.ValidatorFilename); err != nil {
+			return nil, errors.Wrapf(err, "cannot watch validator configuration file %s", config.ValidatorFilename)
+		}
+	}
+
 	return &State{
-		adapter:        a,
-		deliveredLinks: deliveredLinks,
-		checkedLinks:   checkedLinks,
+		adapter:          a,
+		deliveredLinks:   deliveredLinks,
+		checkedLinks:     checkedLinks,
+		validatorWatcher: watcher,
+		validatorChan:    validatorChan,
 	}, nil
+}
+
+func loadValidatorFile(filename string, validatorChan chan validator.Validator) {
+	validators, err := validator.LoadConfig(filename)
+	if err != nil {
+		log.Warnf("Could not load validator configuration: %s", err.Error())
+	} else {
+		select {
+		case validatorChan <- validator.NewMultiValidator(validators):
+		}
+	}
+}
+
+// UpdateValidators updates validators if a new version is available
+func (s *State) UpdateValidators() {
+	if s.validatorWatcher != nil {
+		var validatorFile string
+		select {
+		case event := <-s.validatorWatcher.Events:
+			if event.Op&fsnotify.Write == fsnotify.Write {
+				validatorFile = event.Name
+			}
+		case err := <-s.validatorWatcher.Errors:
+			log.Warnf("Validator file watcher error caught: %s", err)
+		default:
+			break
+		}
+		if validatorFile != "" {
+			go loadValidatorFile(validatorFile, s.validatorChan)
+		}
+	}
+	select {
+	case validator := <-s.validatorChan:
+		log.Info("Validator updated")
+		s.validator = validator
+	default:
+		return
+	}
 }
 
 // Check checks if creating this link is a valid operation

--- a/tmstore/testdata/rules.new.json
+++ b/tmstore/testdata/rules.new.json
@@ -1,0 +1,29 @@
+{
+  "testProcess": {
+    "pki": {
+      "charlie@stratumn.com": {
+        "keys": ["TESTKEY2"],
+        "roles": ["employee"]
+      },
+      "Dave Gahan": {
+        "keys": ["hmxvE+c9PwGUSEVZQ10RPaTP5SkuTR60pJ+Bhwqih48="],
+        "roles": ["it"]
+      }
+    },
+    "types": {
+      "init": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "string": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "action": {
+        "signatures": ["employee"]
+      }
+    }
+  }
+}

--- a/tmstore/tmstore_test.go
+++ b/tmstore/tmstore_test.go
@@ -16,9 +16,12 @@ package tmstore
 
 import (
 	"encoding/base64"
+	"io/ioutil"
 	"net/http"
+	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stratumn/go-indigocore/cs/cstesting"
 	"github.com/stratumn/go-indigocore/jsonhttp"
@@ -27,8 +30,11 @@ import (
 	"github.com/stratumn/go-indigocore/tmpop"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	abci "github.com/tendermint/abci/types"
 	"golang.org/x/crypto/ed25519"
 )
+
+const itPrivKey = "3t39DaJp54JXnBuBR31K889hqAFNms3V5U5cWqaY5VmGbG8T5z0/AZRIRVlDXRE9pM/lKS5NHrSkn4GHCqKHjw=="
 
 var (
 	tmstore *TMStore
@@ -48,11 +54,34 @@ func resetTMPop(_ store.Adapter) {
 	ResetNode()
 }
 
+func updateValidatorRulesFile(t *testing.T, in, out string) {
+	rulesInputFile, err := os.OpenFile(in, os.O_RDONLY, 0666)
+	defer rulesInputFile.Close()
+	content, err := ioutil.ReadAll(rulesInputFile)
+	require.NoErrorf(t, err, "Cannot read validator rule file %s", in)
+	err = ioutil.WriteFile(out, content, 0666)
+	require.NoErrorf(t, err, "Cannot write validator rule file %s", out)
+
+	if testTmpop != nil {
+		tmInfo := testTmpop.Info(abci.RequestInfo{})
+		testTmpop.BeginBlock(abci.RequestBeginBlock{
+			Hash: tmInfo.LastBlockAppHash,
+			Header: &abci.Header{
+				AppHash: tmInfo.LastBlockAppHash,
+				Height:  tmInfo.LastBlockHeight,
+			},
+		})
+	}
+}
+
 func TestTMStore(t *testing.T) {
-	testConfig := &tmpop.Config{}
+	rulesFilename := filepath.Join("testdata", "rules.test.json")
+	updateValidatorRulesFile(t, "/dev/null", rulesFilename)
+	testConfig := &tmpop.Config{ValidatorFilename: rulesFilename}
 	node := StartNode(testConfig)
 	defer node.Wait()
 	defer node.Stop()
+	defer os.Remove(rulesFilename)
 
 	t.Run("Store test cases", func(t *testing.T) {
 		storetestcases.Factory{
@@ -65,9 +94,8 @@ func TestTMStore(t *testing.T) {
 		tmstore, err := newTestTMStore()
 		require.NoError(t, err)
 
-		*testConfig = tmpop.Config{
-			ValidatorFilename: filepath.Join("testdata", "rules.json"),
-		}
+		updateValidatorRulesFile(t, filepath.Join("testdata", "rules.json"), rulesFilename)
+		time.Sleep(500 * time.Millisecond)
 
 		t.Run("Validation succeeds", func(t *testing.T) {
 			l := cstesting.RandomLink()
@@ -75,7 +103,7 @@ func TestTMStore(t *testing.T) {
 			l.Meta["type"] = "init"
 			l.State["string"] = "test"
 
-			privBytes, _ := base64.StdEncoding.DecodeString("3t39DaJp54JXnBuBR31K889hqAFNms3V5U5cWqaY5VmGbG8T5z0/AZRIRVlDXRE9pM/lKS5NHrSkn4GHCqKHjw==")
+			privBytes, _ := base64.StdEncoding.DecodeString(itPrivKey)
 			ITPrivateKey := ed25519.PrivateKey(privBytes)
 			l = cstesting.SignLinkWithKey(l, ITPrivateKey)
 
@@ -110,6 +138,33 @@ func TestTMStore(t *testing.T) {
 			errHTTP, ok := err.(jsonhttp.ErrHTTP)
 			assert.True(t, ok, "Invalid error received: want ErrHTTP")
 			assert.Equal(t, http.StatusBadRequest, errHTTP.Status())
+		})
+
+		t.Run("Validation rules update succeeds", func(t *testing.T) {
+			l := cstesting.RandomLink()
+			l.Meta["process"] = "testProcess"
+			l.Meta["type"] = "action"
+			l.State["string"] = "test"
+
+			privBytes, _ := base64.StdEncoding.DecodeString(itPrivKey)
+			ITPrivateKey := ed25519.PrivateKey(privBytes)
+			l = cstesting.SignLinkWithKey(l, ITPrivateKey)
+
+			_, err = tmstore.CreateLink(l)
+			assert.NoError(t, err, "CreateLink() failed")
+
+			updateValidatorRulesFile(t, filepath.Join("testdata", "rules.new.json"), rulesFilename)
+			time.Sleep(500 * time.Millisecond)
+
+			l = cstesting.RandomLink()
+			l.Meta["process"] = "testProcess"
+			l.Meta["type"] = "action"
+			l.State["string"] = "test"
+
+			l = cstesting.SignLinkWithKey(l, ITPrivateKey)
+
+			_, err = tmstore.CreateLink(l)
+			assert.Error(t, err, "CreateLink() should failed because signature is missing")
 		})
 	})
 


### PR DESCRIPTION
This PR avoids reading the validator rules file at each begin block. There is a file watcher on file which reloads validators
The library fsnotify is used and will be removed in a next PR prefering reading data from segments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/go-indigocore/345)
<!-- Reviewable:end -->
