### PR TITLE
validator: add transitions

### DIFF
--- a/validator/configloader.go
+++ b/validator/configloader.go
@@ -37,8 +37,9 @@ var (
 type processesRules map[string]rulesSchema
 
 type rulesSchema struct {
-	PKI   json.RawMessage `json:"pki"`
-	Types json.RawMessage `json:"types"`
+	PKI         json.RawMessage `json:"pki"`
+	Types       json.RawMessage `json:"types"`
+	Transitions json.RawMessage `json:"transitions"`
 }
 
 type rulesListener func(process string, schema rulesSchema, validators []Validator)
@@ -73,16 +74,13 @@ func LoadConfigContent(data []byte, listener rulesListener) ([]Validator, error)
 // LoadProcessRules loads the validators configuration from a slice of processRule.
 // The configuration returned can then be used in NewMultiValidator().
 func LoadProcessRules(rules processesRules, listener rulesListener) ([]Validator, error) {
-	var err error
 	var validators []Validator
 	for process, schema := range rules {
-		var pki *PKI
-		if schema.PKI != nil {
-			pki, err = loadPKIConfig(schema.PKI)
-			if err != nil {
-				return nil, errors.WithStack(err)
-			}
+		pki, err := loadPKIConfig(schema.PKI)
+		if err != nil {
+			return nil, errors.WithStack(err)
 		}
+
 		processValidators, err := loadValidatorsConfig(process, schema.Types, pki)
 		if err != nil {
 			return nil, err
@@ -98,6 +96,9 @@ func LoadProcessRules(rules processesRules, listener rulesListener) ([]Validator
 // loadPKIConfig deserializes json into a PKI struct.
 // It checks that public keys are base64 encoded.
 func loadPKIConfig(data json.RawMessage) (*PKI, error) {
+	if data == nil {
+		return nil, nil
+	}
 	var jsonData PKI
 	err := json.Unmarshal(data, &jsonData)
 	if err != nil {
@@ -107,7 +108,7 @@ func loadPKIConfig(data json.RawMessage) (*PKI, error) {
 	for _, id := range jsonData {
 		for _, key := range id.Keys {
 			if _, err := base64.StdEncoding.DecodeString(key); key == "" || err != nil {
-				return nil, errors.Wrap(ErrBadPublicKey, "Error while parsing PKI")
+				return nil, errors.Wrap(ErrBadPublicKey, "error while parsing PKI")
 			}
 		}
 	}
@@ -115,8 +116,9 @@ func loadPKIConfig(data json.RawMessage) (*PKI, error) {
 }
 
 type jsonValidatorData struct {
-	Signatures []string         `json:"signatures"`
-	Schema     *json.RawMessage `json:"schema"`
+	Signatures  []string            `json:"signatures"`
+	Schema      *json.RawMessage    `json:"schema"`
+	Transitions map[string][]string `json:"transitions"`
 }
 
 func loadValidatorsConfig(process string, data json.RawMessage, pki *PKI) ([]Validator, error) {
@@ -131,7 +133,7 @@ func loadValidatorsConfig(process string, data json.RawMessage, pki *PKI) ([]Val
 		if linkType == "" {
 			return nil, ErrMissingLinkType
 		}
-		if len(val.Signatures) == 0 && val.Schema == nil {
+		if len(val.Signatures) == 0 && val.Schema == nil && len(val.Transitions) == 0 {
 			return nil, ErrInvalidValidator
 		}
 
@@ -154,6 +156,9 @@ func loadValidatorsConfig(process string, data json.RawMessage, pki *PKI) ([]Val
 				return nil, err
 			}
 			validators = append(validators, schemaValidator)
+		}
+		if len(val.Transitions) > 0 {
+			validators = append(validators, newTransitionValidator(baseConfig, val.Transitions))
 		}
 	}
 

--- a/validator/configloader.go
+++ b/validator/configloader.go
@@ -116,9 +116,9 @@ func loadPKIConfig(data json.RawMessage) (*PKI, error) {
 }
 
 type jsonValidatorData struct {
-	Signatures  []string            `json:"signatures"`
-	Schema      *json.RawMessage    `json:"schema"`
-	Transitions map[string][]string `json:"transitions"`
+	Signatures  []string         `json:"signatures"`
+	Schema      *json.RawMessage `json:"schema"`
+	Transitions []string         `json:"transitions"`
 }
 
 func loadValidatorsConfig(process string, data json.RawMessage, pki *PKI) ([]Validator, error) {

--- a/validator/configloader_test.go
+++ b/validator/configloader_test.go
@@ -158,7 +158,7 @@ func TestLoadConfig_Success(t *testing.T) {
 
 func TestLoadValidators_Error(t *testing.T) {
 
-	t.Run("Missing link type", func(T *testing.T) {
+	t.Run("Missing process type", func(T *testing.T) {
 		const invalidValidatorConfig = `
 		{
 			"": {

--- a/validator/configloader_test.go
+++ b/validator/configloader_test.go
@@ -158,7 +158,7 @@ func TestLoadConfig_Success(t *testing.T) {
 
 func TestLoadValidators_Error(t *testing.T) {
 
-	t.Run("Missing process type", func(T *testing.T) {
+	t.Run("Missing process", func(T *testing.T) {
 		const invalidValidatorConfig = `
 		{
 			"": {

--- a/validator/configloader_test.go
+++ b/validator/configloader_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestLoadConfig_Success(t *testing.T) {
 
-	t.Run("schema & signatures", func(T *testing.T) {
+	t.Run("schema & signatures & transitions", func(T *testing.T) {
 		testFile := createTempFile(t, validJSONConfig)
 		defer os.Remove(testFile)
 		validators, err := LoadConfig(testFile, nil)
@@ -32,26 +32,34 @@ func TestLoadConfig_Success(t *testing.T) {
 		assert.NoError(t, err, "LoadConfig()")
 		assert.NotNil(t, validators)
 
-		var schemaValidatorCount, pkiValidatorCount int
+		var schemaValidatorCount, pkiValidatorCount, transitionValidatorCount int
 		for _, v := range validators {
 			if _, ok := v.(*pkiValidator); ok {
 				pkiValidatorCount++
 			} else if _, ok := v.(*schemaValidator); ok {
 				schemaValidatorCount++
+			} else if _, ok := v.(*transitionValidator); ok {
+				transitionValidatorCount++
 			}
 		}
 		assert.Equal(t, 3, schemaValidatorCount)
 		assert.Equal(t, 2, pkiValidatorCount)
+		assert.Equal(t, 4, transitionValidatorCount)
+	})
 
+	t.Run("schema & signatures & transitions with listener", func(T *testing.T) {
+		testFile := createTempFile(t, validJSONConfig)
+		defer os.Remove(testFile)
 		validatorProcessCount := 0
 		validatorCount := 0
-		validators, err = LoadConfig(testFile, func(process string, schema rulesSchema, validators []Validator) {
+		validators, err := LoadConfig(testFile, func(process string, schema rulesSchema, validators []Validator) {
 			validatorProcessCount++
 			validatorCount = validatorCount + len(validators)
 		})
 		assert.NoError(t, err, "LoadConfig()")
 		assert.NotNil(t, validators)
 		assert.Equal(t, 2, validatorProcessCount)
+		assert.Equal(t, 9, validatorCount)
 		assert.Len(t, validators, validatorCount)
 	})
 
@@ -62,21 +70,19 @@ func TestLoadConfig_Success(t *testing.T) {
 			"testProcess": {
 			  "pki": {
 			    "alice.vandenbudenmayer@stratumn.com": {
-			      "keys": ["TESTKEY1"],
-			      "name": "Alice Van den Budenmayer",
-			      "roles": ["employee"]
+					"keys": ["TESTKEY1"],
+					"name": "Alice Van den Budenmayer",
+					"roles": ["employee"]
 			    }
 			  },
 			  "types": {
-			      "init": {
-				"signatures": null,      
-				"schema": {}
-			      }
-			  }
+					"init": {
+						"signatures": null,      
+						"schema": {}
+					}
+			  	}
 			}
-		      }
-		      
-	`
+		}`
 
 		testFile := createTempFile(t, validJSONSig)
 		defer os.Remove(testFile)
@@ -86,8 +92,7 @@ func TestLoadConfig_Success(t *testing.T) {
 		assert.NotNil(t, validators)
 
 		require.Len(t, validators, 1)
-		_, ok := validators[0].(*schemaValidator)
-		assert.True(t, ok)
+		assert.IsType(t, &schemaValidator{}, validators[0])
 	})
 
 	t.Run("Empty signatures", func(T *testing.T) {
@@ -96,25 +101,20 @@ func TestLoadConfig_Success(t *testing.T) {
 		{
 			"test": {
 			    "pki": {
-				"alice.vandenbudenmayer@stratumn.com": {
-				    "keys": [
-					"TESTKEY1"
-				    ],
-				    "name": "Alice Van den Budenmayer",
-				    "roles": [
-					"employee"
-				    ]
-				}
+					"alice.vandenbudenmayer@stratumn.com": {
+						"keys": ["TESTKEY1"],
+						"name": "Alice Van den Budenmayer",
+						"roles": ["employee"]
+					}
 			    },
 			    "types": {
-				"init": {
-				    "signatures": [],
-				    "schema": {}
-				}
+					"init": {
+						"signatures": [],
+						"schema": {}
+					}
 			    }
 			}
-		    }
-		`
+		}`
 
 		testFile := createTempFile(t, validJSONSig)
 		defer os.Remove(testFile)
@@ -124,8 +124,7 @@ func TestLoadConfig_Success(t *testing.T) {
 		assert.NotNil(t, validators)
 
 		require.Len(t, validators, 1)
-		_, ok := validators[0].(*schemaValidator)
-		assert.True(t, ok)
+		assert.IsType(t, &schemaValidator{}, validators[0])
 	})
 
 	t.Run("No PKI", func(T *testing.T) {
@@ -141,8 +140,7 @@ func TestLoadConfig_Success(t *testing.T) {
 				}
 			    }
 			}
-		    }
-		`
+		}`
 
 		testFile := createTempFile(t, validJSONSig)
 		defer os.Remove(testFile)
@@ -153,13 +151,51 @@ func TestLoadConfig_Success(t *testing.T) {
 
 		assert.Len(t, validators, 1)
 		require.Len(t, validators, 1)
-		_, ok := validators[0].(*schemaValidator)
-		assert.True(t, ok)
+		assert.IsType(t, &schemaValidator{}, validators[0])
 	})
 
 }
 
 func TestLoadValidators_Error(t *testing.T) {
+
+	t.Run("Missing link type", func(T *testing.T) {
+		const invalidValidatorConfig = `
+		{
+			"": {
+			  "types": {
+			    "init": {
+					"schema": {}
+				}
+			  },
+			  "pki": {}
+			}
+		}`
+		testFile := createTempFile(t, invalidValidatorConfig)
+		validators, err := LoadConfig(testFile, nil)
+
+		assert.Nil(t, validators)
+		assert.EqualError(t, err, ErrMissingProcess.Error())
+	})
+
+	t.Run("Missing link type", func(T *testing.T) {
+		const invalidValidatorConfig = `
+		{
+			"test": {
+			  "types": {
+			    "": {
+					"schema": {}
+				}
+			  },
+			  "pki": {}
+			}
+		}`
+		testFile := createTempFile(t, invalidValidatorConfig)
+		validators, err := LoadConfig(testFile, nil)
+
+		assert.Nil(t, validators)
+		assert.EqualError(t, err, ErrMissingLinkType.Error())
+	})
+
 	t.Run("Missing schema", func(T *testing.T) {
 		const invalidValidatorConfig = `
 		{
@@ -169,8 +205,7 @@ func TestLoadValidators_Error(t *testing.T) {
 			  },
 			  "pki": {}
 			}
-		}
-	`
+		}`
 		testFile := createTempFile(t, invalidValidatorConfig)
 		validators, err := LoadConfig(testFile, nil)
 
@@ -187,9 +222,27 @@ func TestLoadValidators_Error(t *testing.T) {
 					"signatures": "test"
 				    }
 				}
-			    }
 			}
-		    `
+		}`
+		testFile := createTempFile(t, invalidValidatorConfig)
+		defer os.Remove(testFile)
+		validators, err := LoadConfig(testFile, nil)
+
+		assert.Nil(t, validators)
+		assert.Error(t, err)
+	})
+
+	t.Run("Bad transitions validator", func(T *testing.T) {
+		const invalidValidatorConfig = `
+		{
+			"test": {
+				"types": {
+				    "init": {
+					"transitions": "test"
+				    }
+				}
+			}
+		}`
 		testFile := createTempFile(t, invalidValidatorConfig)
 		defer os.Remove(testFile)
 		validators, err := LoadConfig(testFile, nil)
@@ -246,6 +299,6 @@ func TestLoadPKI_Error(t *testing.T) {
 		validators, err := LoadConfig(testFile, nil)
 
 		assert.Nil(t, validators)
-		assert.EqualError(t, err, "Error while parsing PKI: public key must be a non null base64 encoded string")
+		assert.EqualError(t, err, "error while parsing PKI: public key must be a non null base64 encoded string")
 	})
 }

--- a/validator/pki.go
+++ b/validator/pki.go
@@ -100,7 +100,7 @@ func (pv pkiValidator) ShouldValidate(link *cs.Link) bool {
 	return pv.Config.ShouldValidate(link)
 }
 
-// Validate checks that the provided dignatures match the required ones.
+// Validate checks that the provided signatures match the required ones.
 // a requirement can either be: a public key, a name defined in PKI, a role defined in PKI.
 func (pv pkiValidator) Validate(_ store.SegmentReader, link *cs.Link) error {
 	for _, required := range pv.RequiredSignatures {

--- a/validator/pki.go
+++ b/validator/pki.go
@@ -75,15 +75,15 @@ type Identity struct {
 // pkiValidator validates the json signature of a link's state.
 type pkiValidator struct {
 	Config             *validatorBaseConfig
-	requiredSignatures []string
-	pki                *PKI
+	RequiredSignatures []string
+	PKI                *PKI
 }
 
 func newPkiValidator(baseConfig *validatorBaseConfig, required []string, pki *PKI) Validator {
 	return &pkiValidator{
 		Config:             baseConfig,
-		requiredSignatures: required,
-		pki:                pki,
+		RequiredSignatures: required,
+		PKI:                pki,
 	}
 }
 
@@ -95,26 +95,18 @@ func (pv pkiValidator) Hash() (*types.Bytes32, error) {
 	validationsHash := types.Bytes32(sha256.Sum256(b))
 	return &validationsHash, nil
 }
+
 func (pv pkiValidator) ShouldValidate(link *cs.Link) bool {
 	return pv.Config.ShouldValidate(link)
-}
-
-func (pv pkiValidator) isSignatureRequired(publicKey string) bool {
-	for _, required := range pv.requiredSignatures {
-		if pv.pki.matchRequirement(required, publicKey) {
-			return true
-		}
-	}
-	return false
 }
 
 // Validate checks that the provided dignatures match the required ones.
 // a requirement can either be: a public key, a name defined in PKI, a role defined in PKI.
 func (pv pkiValidator) Validate(_ store.SegmentReader, link *cs.Link) error {
-	for _, required := range pv.requiredSignatures {
+	for _, required := range pv.RequiredSignatures {
 		fulfilled := false
 		for _, sig := range link.Signatures {
-			if pv.pki.matchRequirement(required, sig.PublicKey) {
+			if pv.PKI.matchRequirement(required, sig.PublicKey) {
 				fulfilled = true
 				break
 			}

--- a/validator/schema.go
+++ b/validator/schema.go
@@ -30,8 +30,9 @@ import (
 
 // schemaValidator validates the json schema of a link's state.
 type schemaValidator struct {
-	Config *validatorBaseConfig
-	Schema *gojsonschema.Schema
+	Config     *validatorBaseConfig
+	schema     *gojsonschema.Schema
+	SchemaHash types.Bytes32
 }
 
 func newSchemaValidator(baseConfig *validatorBaseConfig, schemaData []byte) (Validator, error) {
@@ -41,8 +42,9 @@ func newSchemaValidator(baseConfig *validatorBaseConfig, schemaData []byte) (Val
 	}
 
 	return &schemaValidator{
-		Config: baseConfig,
-		Schema: schema,
+		Config:     baseConfig,
+		schema:     schema,
+		SchemaHash: types.Bytes32(sha256.Sum256(schemaData)),
 	}, nil
 }
 
@@ -67,7 +69,7 @@ func (sv schemaValidator) Validate(_ store.SegmentReader, link *cs.Link) error {
 	}
 
 	stateData := gojsonschema.NewBytesLoader(stateBytes)
-	result, err := sv.Schema.Validate(stateData)
+	result, err := sv.schema.Validate(stateData)
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/validator/schema_test.go
+++ b/validator/schema_test.go
@@ -47,6 +47,7 @@ const testSellSchema = `
 }`
 
 func TestSchemaValidatorConfig(t *testing.T) {
+	t.Parallel()
 	validSchema := []byte(testSellSchema)
 	process := "p1"
 	linkType := "sell"
@@ -95,6 +96,7 @@ func TestSchemaValidatorConfig(t *testing.T) {
 }
 
 func TestSchemaValidator(t *testing.T) {
+	t.Parallel()
 	schema := []byte(testSellSchema)
 	baseCfg, err := newValidatorBaseConfig("p1", "sell")
 	require.NoError(t, err)
@@ -143,4 +145,20 @@ func TestSchemaValidator(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSchemaHash(t *testing.T) {
+	t.Parallel()
+	baseCfg, err := newValidatorBaseConfig("foo", "bar")
+	require.NoError(t, err)
+	v1, err1 := newSchemaValidator(baseCfg, []byte(testSellSchema))
+	v2, err2 := newSchemaValidator(baseCfg, []byte(`{"type": "object","properties": {"seller": {"type": "string"}}, "required": ["seller"]}`))
+
+	hash1, err1 := v1.Hash()
+	hash2, err2 := v2.Hash()
+	assert.NoError(t, err1)
+	assert.NoError(t, err2)
+	assert.NotNil(t, hash1)
+	assert.NotNil(t, hash2)
+	assert.NotEqual(t, hash1.String(), hash2.String())
 }

--- a/validator/transition.go
+++ b/validator/transition.go
@@ -1,0 +1,94 @@
+// Copyright 2017 Stratumn SAS. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validator
+
+import (
+	"crypto/sha256"
+
+	cj "github.com/gibson042/canonicaljson-go"
+	"github.com/pkg/errors"
+
+	"github.com/stratumn/go-indigocore/cs"
+	"github.com/stratumn/go-indigocore/store"
+	"github.com/stratumn/go-indigocore/types"
+)
+
+type transitionSources = []string
+
+type allowedTransitions = map[string]transitionSources
+
+// transitionValidator defines the source state where a transition can be applied and its destination state.
+type transitionValidator struct {
+	Config      *validatorBaseConfig
+	Transitions allowedTransitions
+}
+
+func newTransitionValidator(baseConfig *validatorBaseConfig, transitions allowedTransitions) Validator {
+	return &transitionValidator{
+		Config:      baseConfig,
+		Transitions: transitions,
+	}
+}
+
+func (tv transitionValidator) Hash() (*types.Bytes32, error) {
+	b, err := cj.Marshal(tv)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	validationsHash := types.Bytes32(sha256.Sum256(b))
+	return &validationsHash, nil
+}
+
+func (tv transitionValidator) ShouldValidate(link *cs.Link) bool {
+	return tv.Config.ShouldValidate(link)
+}
+
+// Validate checks that the provided dignatures match the required ones.
+// a requirement can either be: a public key, a name defined in PKI, a role defined in PKI.
+func (tv transitionValidator) Validate(store store.SegmentReader, link *cs.Link) error {
+	error := func(src string) error {
+		return errors.Errorf("no transition found %s --%s--> %s", src, link.Meta.Action, tv.Config.LinkType)
+	}
+
+	transitions, found := tv.Transitions[link.Meta.Action]
+	if !found {
+		return error("###")
+	}
+
+	prevLinkHash := link.Meta.GetPrevLinkHash()
+	if prevLinkHash == nil {
+		for _, t := range transitions {
+			if t == "" {
+				return nil
+			}
+		}
+		return error("()")
+	}
+
+	seg, err := store.GetSegment(prevLinkHash)
+	if err != nil {
+		return errors.Wrapf(err, "cannot retrieve previous segment %s", prevLinkHash.String())
+	}
+	if seg == nil {
+		return errors.Errorf("previous segment not found: %s", prevLinkHash.String())
+	}
+
+	for _, t := range transitions {
+		if t == seg.Link.Meta.Type {
+			return nil
+		}
+	}
+	return error(seg.Link.Meta.Type)
+}

--- a/validator/transition.go
+++ b/validator/transition.go
@@ -55,8 +55,9 @@ func (tv transitionValidator) ShouldValidate(link *cs.Link) bool {
 	return tv.Config.ShouldValidate(link)
 }
 
-// Validate checks that the provided dignatures match the required ones.
-// a requirement can either be: a public key, a name defined in PKI, a role defined in PKI.
+// Validate checks that the link follows a valid transition.
+// If there is no previous link, an empty link has to be allowed,
+// Otherwise the meta.type of the prevLink must exist in authorized previous statement.
 func (tv transitionValidator) Validate(store store.SegmentReader, link *cs.Link) error {
 	error := func(src string) error {
 		return errors.Errorf("no transition found %s --%s--> %s", src, link.Meta.Action, tv.Config.LinkType)

--- a/validator/transition.go
+++ b/validator/transition.go
@@ -25,9 +25,7 @@ import (
 	"github.com/stratumn/go-indigocore/types"
 )
 
-type transitionSources = []string
-
-type allowedTransitions = map[string]transitionSources
+type allowedTransitions = []string
 
 // transitionValidator defines the source state where a transition can be applied and its destination state.
 type transitionValidator struct {
@@ -60,17 +58,12 @@ func (tv transitionValidator) ShouldValidate(link *cs.Link) bool {
 // Otherwise the meta.type of the prevLink must exist in authorized previous statement.
 func (tv transitionValidator) Validate(store store.SegmentReader, link *cs.Link) error {
 	error := func(src string) error {
-		return errors.Errorf("no transition found %s --%s--> %s", src, link.Meta.Action, tv.Config.LinkType)
-	}
-
-	transitions, found := tv.Transitions[link.Meta.Action]
-	if !found {
-		return error("###")
+		return errors.Errorf("no transition found %s --> %s", src, tv.Config.LinkType)
 	}
 
 	prevLinkHash := link.Meta.GetPrevLinkHash()
 	if prevLinkHash == nil {
-		for _, t := range transitions {
+		for _, t := range tv.Transitions {
 			if t == "" {
 				return nil
 			}
@@ -86,7 +79,7 @@ func (tv transitionValidator) Validate(store store.SegmentReader, link *cs.Link)
 		return errors.Errorf("previous segment not found: %s", prevLinkHash.String())
 	}
 
-	for _, t := range transitions {
+	for _, t := range tv.Transitions {
 		if t == seg.Link.Meta.Type {
 			return nil
 		}

--- a/validator/transition_test.go
+++ b/validator/transition_test.go
@@ -84,7 +84,7 @@ func populateStore(t *testing.T) (store.Adapter, stateMachineLinks) {
 	_, err := store.CreateLink(links.createdProduct)
 	require.NoError(t, err)
 
-	append := func(prevLink *cs.Link, state, action string) *cs.Link {
+	appendLink := func(prevLink *cs.Link, state, action string) *cs.Link {
 		l := cstesting.RandomBranch(prevLink)
 		l.Meta.Type = state
 		l.Meta.Action = action
@@ -93,15 +93,15 @@ func populateStore(t *testing.T) (store.Adapter, stateMachineLinks) {
 		return l
 	}
 
-	links.signedProduct = append(links.createdProduct, stateSignedProduct, actionSign)
-	links.finalProduct = append(links.signedProduct, stateFinalProduct, actionTransform)
-	links.finalSignedProduct = append(links.finalProduct, stateFinalSignedProduct, actionSign)
+	links.signedProduct = appendLink(links.createdProduct, stateSignedProduct, actionSign)
+	links.finalProduct = appendLink(links.signedProduct, stateFinalProduct, actionTransform)
+	links.finalSignedProduct = appendLink(links.finalProduct, stateFinalSignedProduct, actionSign)
 
-	links.approvedProduct = append(links.createdProduct, stateFinalSignedProduct, actionApprove)
+	links.approvedProduct = appendLink(links.createdProduct, stateFinalSignedProduct, actionApprove)
 
-	links.hacked1Product = append(links.createdProduct, stateHackedProduct, actionHack)
-	links.hacked2Product = append(links.hacked1Product, stateHackedProduct, actionHack)
-	links.hackedFinalProduct = append(links.hacked2Product, stateFinalSignedProduct, actionApprove)
+	links.hacked1Product = appendLink(links.createdProduct, stateHackedProduct, actionHack)
+	links.hacked2Product = appendLink(links.hacked1Product, stateHackedProduct, actionHack)
+	links.hackedFinalProduct = appendLink(links.hacked2Product, stateFinalSignedProduct, actionApprove)
 	return store, links
 }
 

--- a/validator/transition_test.go
+++ b/validator/transition_test.go
@@ -45,14 +45,11 @@ const (
 
 var (
 	// Allowed transitions
-	createdProductTransitions     = map[string][]string{actionCreate: []string{""}}
-	signedProductTransitions      = map[string][]string{actionSign: []string{stateCreatedProduct}}
-	finalProductTransitions       = map[string][]string{actionTransform: []string{stateSignedProduct}}
-	hackedProductTransitions      = map[string][]string{actionHack: []string{stateCreatedProduct, stateHackedProduct}}
-	finalSignedProductTransitions = map[string][]string{
-		actionSign:    []string{stateFinalProduct},
-		actionApprove: []string{stateCreatedProduct, stateHackedProduct},
-	}
+	createdProductTransitions     = []string{""}
+	signedProductTransitions      = []string{stateCreatedProduct}
+	finalProductTransitions       = []string{stateSignedProduct}
+	hackedProductTransitions      = []string{stateCreatedProduct, stateHackedProduct}
+	finalSignedProductTransitions = []string{stateFinalProduct, stateCreatedProduct, stateHackedProduct}
 )
 
 type stateMachineLinks struct {
@@ -127,16 +124,9 @@ func TestTransitionValidator(t *testing.T) {
 		{
 			name:        "bad init",
 			valid:       false,
-			err:         `no transition found \(\) --create--> createdProduct`,
+			err:         `no transition found \(\) --> createdProduct`,
 			link:        links.createdProduct,
-			transitions: map[string][]string{"create": []string{"src1", "src2"}},
-		},
-		{
-			name:        "bad type",
-			valid:       false,
-			err:         "no transition found ### --create--> createdProduct",
-			link:        links.createdProduct,
-			transitions: map[string][]string{"doStuff": []string{"src1", "src2"}},
+			transitions: []string{"src1", "src2"},
 		},
 		{
 			name:        "good final transition",
@@ -159,9 +149,9 @@ func TestTransitionValidator(t *testing.T) {
 		{
 			name:        "invalid transition",
 			valid:       false,
-			err:         "no transition found signedProduct --transform--> finalProduct",
-			link:        links.finalProduct,
-			transitions: map[string][]string{actionTransform: []string{stateCreatedProduct}},
+			err:         "no transition found finalProduct --> finalSignedProduct",
+			link:        links.finalSignedProduct,
+			transitions: []string{stateCreatedProduct},
 		},
 		{
 			name:  "prevLink not found",
@@ -172,7 +162,7 @@ func TestTransitionValidator(t *testing.T) {
 				l.Meta.PrevLinkHash = testutil.RandomHash().String()
 				return l
 			}(),
-			transitions: map[string][]string{actionTransform: []string{stateCreatedProduct}},
+			transitions: []string{stateCreatedProduct},
 		},
 	}
 

--- a/validator/transition_test.go
+++ b/validator/transition_test.go
@@ -1,0 +1,259 @@
+// Copyright 2017 Stratumn SAS. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validator
+
+import (
+	"testing"
+
+	"github.com/stratumn/go-indigocore/dummystore"
+	"github.com/stratumn/go-indigocore/testutil"
+
+	"github.com/stratumn/go-indigocore/cs"
+	"github.com/stratumn/go-indigocore/cs/cstesting"
+	"github.com/stratumn/go-indigocore/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	process = "test"
+
+	stateCreatedProduct     = "createdProduct"
+	stateSignedProduct      = "signedProduct"
+	stateFinalProduct       = "finalProduct"
+	stateFinalSignedProduct = "finalSignedProduct"
+	stateHackedProduct      = "hackedProduct"
+
+	actionCreate    = "create"
+	actionSign      = "sign"
+	actionTransform = "transform"
+	actionApprove   = "approve"
+	actionHack      = "hack"
+)
+
+var (
+	// Allowed transitions
+	createdProductTransitions     = map[string][]string{actionCreate: []string{""}}
+	signedProductTransitions      = map[string][]string{actionSign: []string{stateCreatedProduct}}
+	finalProductTransitions       = map[string][]string{actionTransform: []string{stateSignedProduct}}
+	hackedProductTransitions      = map[string][]string{actionHack: []string{stateCreatedProduct, stateHackedProduct}}
+	finalSignedProductTransitions = map[string][]string{
+		actionSign:    []string{stateFinalProduct},
+		actionApprove: []string{stateCreatedProduct, stateHackedProduct},
+	}
+)
+
+type stateMachineLinks struct {
+	createdProduct *cs.Link
+
+	// Complete workflow
+	signedProduct      *cs.Link
+	finalProduct       *cs.Link
+	finalSignedProduct *cs.Link
+
+	// Hacked workflow
+	hacked1Product     *cs.Link
+	hacked2Product     *cs.Link
+	hackedFinalProduct *cs.Link
+
+	// Bypass workflow
+	approvedProduct *cs.Link
+}
+
+func populateStore(t *testing.T) (store.Adapter, stateMachineLinks) {
+	store := dummystore.New(nil)
+	require.NotNil(t, store)
+
+	var links stateMachineLinks
+	links.createdProduct = cstesting.RandomLinkWithProcess(process)
+	links.createdProduct.Meta.PrevLinkHash = ""
+	links.createdProduct.Meta.Type = stateCreatedProduct
+	links.createdProduct.Meta.Action = actionCreate
+	_, err := store.CreateLink(links.createdProduct)
+	require.NoError(t, err)
+
+	append := func(prevLink *cs.Link, state, action string) *cs.Link {
+		l := cstesting.RandomBranch(prevLink)
+		l.Meta.Type = state
+		l.Meta.Action = action
+		_, err := store.CreateLink(l)
+		require.NoError(t, err)
+		return l
+	}
+
+	links.signedProduct = append(links.createdProduct, stateSignedProduct, actionSign)
+	links.finalProduct = append(links.signedProduct, stateFinalProduct, actionTransform)
+	links.finalSignedProduct = append(links.finalProduct, stateFinalSignedProduct, actionSign)
+
+	links.approvedProduct = append(links.createdProduct, stateFinalSignedProduct, actionApprove)
+
+	links.hacked1Product = append(links.createdProduct, stateHackedProduct, actionHack)
+	links.hacked2Product = append(links.hacked1Product, stateHackedProduct, actionHack)
+	links.hackedFinalProduct = append(links.hacked2Product, stateFinalSignedProduct, actionApprove)
+	return store, links
+}
+
+func TestTransitionValidator(t *testing.T) {
+	t.Parallel()
+	store, links := populateStore(t)
+
+	type testCase struct {
+		name        string
+		valid       bool
+		err         string
+		link        *cs.Link
+		transitions allowedTransitions
+	}
+
+	testCases := []testCase{
+		{
+			name:        "good init",
+			valid:       true,
+			link:        links.createdProduct,
+			transitions: createdProductTransitions,
+		},
+		{
+			name:        "bad init",
+			valid:       false,
+			err:         `no transition found \(\) --create--> createdProduct`,
+			link:        links.createdProduct,
+			transitions: map[string][]string{"create": []string{"src1", "src2"}},
+		},
+		{
+			name:        "bad type",
+			valid:       false,
+			err:         "no transition found ### --create--> createdProduct",
+			link:        links.createdProduct,
+			transitions: map[string][]string{"doStuff": []string{"src1", "src2"}},
+		},
+		{
+			name:        "good final transition",
+			valid:       true,
+			link:        links.finalSignedProduct,
+			transitions: finalSignedProductTransitions,
+		},
+		{
+			name:        "good fast final transition",
+			valid:       true,
+			link:        links.approvedProduct,
+			transitions: finalSignedProductTransitions,
+		},
+		{
+			name:        "good hacked final transition",
+			valid:       true,
+			link:        links.hackedFinalProduct,
+			transitions: finalSignedProductTransitions,
+		},
+		{
+			name:        "invalid transition",
+			valid:       false,
+			err:         "no transition found signedProduct --transform--> finalProduct",
+			link:        links.finalProduct,
+			transitions: map[string][]string{actionTransform: []string{stateCreatedProduct}},
+		},
+		{
+			name:  "prevLink not found",
+			valid: false,
+			err:   "previous segment not found.*",
+			link: func() *cs.Link {
+				l := cstesting.Clone(links.finalProduct)
+				l.Meta.PrevLinkHash = testutil.RandomHash().String()
+				return l
+			}(),
+			transitions: map[string][]string{actionTransform: []string{stateCreatedProduct}},
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			baseCfg, err := newValidatorBaseConfig(process, tt.link.Meta.Type)
+			require.NoError(t, err)
+			v := newTransitionValidator(baseCfg, tt.transitions)
+
+			err = v.Validate(store, tt.link)
+			if tt.valid {
+				assert.NoError(t, err)
+			} else {
+				assert.Regexp(t, tt.err, err.Error())
+			}
+		})
+	}
+
+}
+
+func TestTransitionShouldValidate(t *testing.T) {
+	t.Parallel()
+	_, links := populateStore(t)
+
+	type testCase struct {
+		name string
+		ret  bool
+		conf *validatorBaseConfig
+		link *cs.Link
+	}
+
+	newConf := func(process, linkType string) *validatorBaseConfig {
+		cfg, err := newValidatorBaseConfig(process, linkType)
+		require.NoError(t, err)
+		return cfg
+	}
+
+	testCases := []testCase{
+		{
+			name: "has to validate",
+			ret:  true,
+			conf: newConf(links.createdProduct.Meta.Process, links.createdProduct.Meta.Type),
+			link: links.createdProduct,
+		},
+		{
+			name: "bad process",
+			ret:  false,
+			conf: newConf("foo", links.createdProduct.Meta.Type),
+			link: links.createdProduct,
+		},
+		{
+			name: "bad state",
+			ret:  false,
+			conf: newConf(links.createdProduct.Meta.Process, "bar"),
+			link: links.createdProduct,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			v := newTransitionValidator(tt.conf, nil)
+			assert.Equal(t, tt.ret, v.ShouldValidate(tt.link))
+		})
+	}
+
+}
+
+func TestTransitionHash(t *testing.T) {
+	t.Parallel()
+	_, links := populateStore(t)
+
+	baseCfg, err := newValidatorBaseConfig(process, links.finalProduct.Meta.Type)
+	require.NoError(t, err)
+	v1 := newTransitionValidator(baseCfg, finalProductTransitions)
+	v2 := newTransitionValidator(baseCfg, createdProductTransitions)
+
+	hash1, err1 := v1.Hash()
+	hash2, err2 := v2.Hash()
+	assert.NoError(t, err1)
+	assert.NoError(t, err2)
+	assert.NotNil(t, hash1)
+	assert.NotNil(t, hash2)
+	assert.NotEqual(t, hash1.String(), hash2.String())
+}

--- a/validator/util_test.go
+++ b/validator/util_test.go
@@ -54,6 +54,9 @@ const validAuctionJSONTypesConfig = `
 				}
 			},
 			"required": ["seller", "lot", "initialPrice"]
+		},
+		"transitions": {
+			"initialize" : [""]
 		}
 	},
 	"bid": {
@@ -69,6 +72,9 @@ const validAuctionJSONTypesConfig = `
 				}
 			},
 			"required": ["buyer", "bidPrice"]
+		},
+		"transitions": {
+			"sendOrder" : ["init", "bid"]
 		}
 	}
 }
@@ -98,10 +104,16 @@ const validChatJSONTypesConfig = `
 				}
 			},
 			"required": ["to", "content"]
+		},
+		"transitions": {
+			"sendMessage" : ["init", "message"]
 		}
 	},
 	"init": {
-		"signatures": ["manager", "it"]
+		"signatures": ["manager", "it"],
+		"transitions": {
+			"init" : [""]
+		}
 	}
 }
 `

--- a/validator/util_test.go
+++ b/validator/util_test.go
@@ -55,9 +55,7 @@ const validAuctionJSONTypesConfig = `
 			},
 			"required": ["seller", "lot", "initialPrice"]
 		},
-		"transitions": {
-			"initialize" : [""]
-		}
+		"transitions": [""]
 	},
 	"bid": {
 		"schema": {
@@ -73,9 +71,7 @@ const validAuctionJSONTypesConfig = `
 			},
 			"required": ["buyer", "bidPrice"]
 		},
-		"transitions": {
-			"sendOrder" : ["init", "bid"]
-		}
+		"transitions": ["init", "bid"]
 	}
 }
 `
@@ -105,15 +101,11 @@ const validChatJSONTypesConfig = `
 			},
 			"required": ["to", "content"]
 		},
-		"transitions": {
-			"sendMessage" : ["init", "message"]
-		}
+		"transitions": ["init", "message"]
 	},
 	"init": {
 		"signatures": ["manager", "it"],
-		"transitions": {
-			"init" : [""]
-		}
+		"transitions": [""]
 	}
 }
 `


### PR DESCRIPTION
Implementation of SRP4.
Validation of transitions.

Here is a rule example:
```
{
    "auction": {
        "pki": {},
        "types": {
            "initState": {
                "transitions": {
                    "initialize" : [""]
                }
            },
            "OrderOnMarket": {
                "transitions": {
                    "sendOrder" : ["initState", "OrderOnMarket"]
                }
            },
            "OrderCanceled": {
                "transitions": {
                    "cancel" : ["initState", "OrderOnMarket"]
                }
            }
        }
    }
}

```

A chainscript type is the state.
Each state has a list of possible transitions defined as _actionName_ and the list of allowed previous states.
An empty previous state is necessary to create the first link of a map
A final state is a state which is not defined in any allowed previous state.

A next PR will come once this PR will be merged to make transition validation mandatory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/go-indigocore/354)
<!-- Reviewable:end -->
