### PR TITLE
Makefile: ignore hidden folders and files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,8 +44,8 @@ DOCKER_PUSH=$(DOCKER_CMD) push
 
 PACKAGES=$(shell $(GO_LIST) ./... | grep -v vendor)
 TEST_PACKAGES=$(shell $(GO_LIST) ./... | grep -v vendor | grep -v testutil | grep -v testcases)
-COVERAGE_SOURCES=$(shell find . -name '*.go' | grep -v 'testutils' | grep -v 'testcases' | grep -v 'doc.go')
-BUILD_SOURCES=$(shell find . -name '*.go' | grep -v 'testutils' | grep -v 'testcases' | grep -v '_test.go' | grep -v 'doc.go')
+COVERAGE_SOURCES=$(shell find * -name '*.go' -not -path "testutil/*" -not -path "*testcases/*" | grep -v 'doc.go')
+BUILD_SOURCES=$(shell find * -name '*.go' -not -path "testutil/*" -not -path "*testcases/*" | grep -v '_test.go' | grep -v 'doc.go')
 COMMANDS=$(shell ls $(COMMAND_DIR))
 
 NIX_EXECS=$(foreach command, $(COMMANDS), $(foreach os-arch, $(NIX_OS_ARCHS), $(DIST_DIR)/$(os-arch)/$(command)))
@@ -56,7 +56,7 @@ NIX_ZIP_FILES=$(foreach command, $(COMMANDS), $(foreach os-arch, $(NIX_OS_ARCHS)
 WIN_ZIP_FILES=$(foreach command, $(COMMANDS), $(foreach os-arch, $(WIN_OS_ARCHS), $(DIST_DIR)/$(os-arch)/$(command).zip))
 ZIP_FILES=$(NIX_ZIP_FILES) $(WIN_ZIP_FILES)
 DOCKER_FILES=$(foreach command, $(COMMANDS), $(DIST_DIR)/$(command).Dockerfile)
-LICENSED_FILES=$(shell find . -name '*.go' | grep -v vendor | grep -v mock)
+LICENSED_FILES=$(shell find * -name '*.go' -not -path "vendor/*" | grep -v mock)
 
 TEST_LIST=$(foreach package, $(TEST_PACKAGES), test_$(package))
 BENCHMARK_LIST=$(foreach package, $(TEST_PACKAGES), benchmark_$(package))


### PR DESCRIPTION
- replaced some `grep -v` by `find -not -path <path>` (@alexppxela perf improvement)

- replace `find .` by `find *` to ignore hidden files (semaphore create a `.semaphore-cache` in the current directory, which made the tests fail)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/go-indigocore/359)
<!-- Reviewable:end -->
