### PR TITLE
monitoring: add tracing to all stores

### DIFF
--- a/bufferedbatch/batch.go
+++ b/bufferedbatch/batch.go
@@ -20,6 +20,10 @@ import (
 	"github.com/stratumn/go-indigocore/cs"
 	"github.com/stratumn/go-indigocore/store"
 	"github.com/stratumn/go-indigocore/types"
+
+	"go.opencensus.io/stats"
+	"go.opencensus.io/tag"
+	"go.opencensus.io/trace"
 )
 
 // Batch can be used as a base class for types
@@ -32,12 +36,16 @@ type Batch struct {
 }
 
 // NewBatch creates a new Batch.
-func NewBatch(a store.Adapter) *Batch {
+func NewBatch(ctx context.Context, a store.Adapter) *Batch {
+	stats.Record(ctx, batchCount.M(1))
 	return &Batch{originalStore: a}
 }
 
 // CreateLink implements github.com/stratumn/go-indigocore/store.LinkWriter.CreateLink.
 func (b *Batch) CreateLink(ctx context.Context, link *cs.Link) (*types.Bytes32, error) {
+	ctx, span := trace.StartSpan(ctx, "bufferedbatch/CreateLink")
+	defer span.End()
+
 	if err := link.Validate(ctx, b.GetSegment); err != nil {
 		return nil, err
 	}
@@ -47,6 +55,9 @@ func (b *Batch) CreateLink(ctx context.Context, link *cs.Link) (*types.Bytes32, 
 
 // GetSegment returns a segment from the cache or delegates the call to the store.
 func (b *Batch) GetSegment(ctx context.Context, linkHash *types.Bytes32) (segment *cs.Segment, err error) {
+	ctx, span := trace.StartSpan(ctx, "bufferedbatch/GetSegment")
+	defer span.End()
+
 	for _, link := range b.Links {
 		lh, err := link.Hash()
 		if err != nil {
@@ -67,6 +78,9 @@ func (b *Batch) GetSegment(ctx context.Context, linkHash *types.Bytes32) (segmen
 
 // FindSegments returns the union of segments in the store and not committed yet.
 func (b *Batch) FindSegments(ctx context.Context, filter *store.SegmentFilter) (cs.SegmentSlice, error) {
+	ctx, span := trace.StartSpan(ctx, "bufferedbatch/FindSegments")
+	defer span.End()
+
 	segments, err := b.originalStore.FindSegments(ctx, filter)
 	if err != nil {
 		return segments, err
@@ -83,6 +97,9 @@ func (b *Batch) FindSegments(ctx context.Context, filter *store.SegmentFilter) (
 
 // GetMapIDs returns the union of mapIds in the store and not committed yet.
 func (b *Batch) GetMapIDs(ctx context.Context, filter *store.MapFilter) ([]string, error) {
+	ctx, span := trace.StartSpan(ctx, "bufferedbatch/GetMapIDs")
+	defer span.End()
+
 	tmpMapIDs, err := b.originalStore.GetMapIDs(ctx, filter)
 	if err != nil {
 		return tmpMapIDs, err
@@ -109,12 +126,25 @@ func (b *Batch) GetMapIDs(ctx context.Context, filter *store.MapFilter) ([]strin
 
 // Write implements github.com/stratumn/go-indigocore/store.Batch.Write.
 func (b *Batch) Write(ctx context.Context) (err error) {
+	ctx, span := trace.StartSpan(ctx, "bufferedbatch/Write")
+	defer span.End()
+
+	stats.Record(ctx, linksPerBatch.M(int64(len(b.Links))))
+
 	for _, link := range b.Links {
 		_, err = b.originalStore.CreateLink(ctx, link)
 		if err != nil {
 			break
 		}
 	}
+
+	if err == nil {
+		ctx, _ = tag.New(ctx, tag.Upsert(writeStatus, "success"))
+	} else {
+		ctx, _ = tag.New(ctx, tag.Upsert(writeStatus, "failure"))
+	}
+
+	stats.Record(ctx, writeCount.M(1))
 
 	return
 }

--- a/bufferedbatch/batch_test.go
+++ b/bufferedbatch/batch_test.go
@@ -29,10 +29,11 @@ import (
 )
 
 func TestBatch_CreateLink(t *testing.T) {
-	a := &storetesting.MockAdapter{}
-	batch := NewBatch(a)
-
 	ctx := context.Background()
+
+	a := &storetesting.MockAdapter{}
+	batch := NewBatch(ctx, a)
+
 	l := cstesting.RandomLink()
 
 	wantedErr := errors.New("error on MockCreateLink")
@@ -55,10 +56,10 @@ func TestBatch_CreateLink(t *testing.T) {
 }
 
 func TestBatch_GetSegment(t *testing.T) {
-	a := &storetesting.MockAdapter{}
-	batch := NewBatch(a)
-
 	ctx := context.Background()
+
+	a := &storetesting.MockAdapter{}
+	batch := NewBatch(ctx, a)
 
 	storedLink := cstesting.RandomLink()
 	storedLinkHash, _ := storedLink.Hash()
@@ -111,10 +112,10 @@ func TestBatch_GetSegment(t *testing.T) {
 }
 
 func TestBatch_FindSegments(t *testing.T) {
-	a := &storetesting.MockAdapter{}
-	batch := NewBatch(a)
-
 	ctx := context.Background()
+
+	a := &storetesting.MockAdapter{}
+	batch := NewBatch(ctx, a)
 
 	storedLink := cstesting.RandomLink()
 	storedLink.Meta.Process = "Foo"
@@ -164,10 +165,10 @@ func TestBatch_FindSegments(t *testing.T) {
 }
 
 func TestBatch_GetMapIDs(t *testing.T) {
-	a := &storetesting.MockAdapter{}
-	batch := NewBatch(a)
-
 	ctx := context.Background()
+
+	a := &storetesting.MockAdapter{}
+	batch := NewBatch(ctx, a)
 
 	storedLink1 := cstesting.RandomLink()
 	storedLink1.Meta.MapID = "Foo1"
@@ -233,10 +234,10 @@ func TestBatch_GetMapIDs(t *testing.T) {
 }
 
 func TestBatch_GetMapIDsWithStoreReturningAnErrorOnGetMapIDs(t *testing.T) {
-	a := &storetesting.MockAdapter{}
-	batch := NewBatch(a)
-
 	ctx := context.Background()
+
+	a := &storetesting.MockAdapter{}
+	batch := NewBatch(ctx, a)
 
 	wantedMapIds := []string{"Foo", "Bar"}
 	notFoundErr := errors.New("Unit test error")
@@ -259,7 +260,7 @@ func TestBatch_WriteLink(t *testing.T) {
 
 	ctx := context.Background()
 
-	batch := NewBatch(a)
+	batch := NewBatch(ctx, a)
 
 	_, err := batch.CreateLink(ctx, l)
 	if err != nil {
@@ -296,7 +297,7 @@ func TestBatch_WriteLinkWithFailure(t *testing.T) {
 		return l.Hash()
 	}
 
-	batch := NewBatch(a)
+	batch := NewBatch(ctx, a)
 
 	_, err := batch.CreateLink(ctx, la)
 	if err != nil {

--- a/bufferedbatch/metrics.go
+++ b/bufferedbatch/metrics.go
@@ -1,0 +1,84 @@
+// Copyright 2017 Stratumn SAS. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bufferedbatch
+
+import (
+	"log"
+
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+)
+
+var (
+	batchCount    *stats.Int64Measure
+	linksPerBatch *stats.Int64Measure
+	writeCount    *stats.Int64Measure
+	writeStatus   tag.Key
+)
+
+func init() {
+	var err error
+	if batchCount, err = stats.Int64(
+		"stratumn/indigocore/bufferedbatch/batch_count",
+		"number of batches created",
+		stats.UnitNone,
+	); err != nil {
+		log.Fatal(err)
+	}
+
+	if linksPerBatch, err = stats.Int64(
+		"stratumn/indigocore/bufferedbatch/links_per_batch",
+		"number of links per batch",
+		stats.UnitNone,
+	); err != nil {
+		log.Fatal(err)
+	}
+
+	if writeCount, err = stats.Int64(
+		"stratumn/indigocore/bufferedbatch/write_count",
+		"number of batch writes",
+		stats.UnitNone,
+	); err != nil {
+		log.Fatal(err)
+	}
+
+	if writeStatus, err = tag.NewKey("batch_write_status"); err != nil {
+		log.Fatal(err)
+	}
+
+	if err = view.Subscribe(
+		&view.View{
+			Name:        "batch_count",
+			Description: "number of batches created",
+			Measure:     batchCount,
+			Aggregation: view.Count(),
+		},
+		&view.View{
+			Name:        "write_count",
+			Description: "number of batch writes",
+			Measure:     writeCount,
+			Aggregation: view.Count(),
+			TagKeys:     []tag.Key{writeStatus},
+		},
+		&view.View{
+			Name:        "links_per_batch",
+			Description: "number of links per batch",
+			Measure:     linksPerBatch,
+			Aggregation: view.Distribution(1, 5, 10, 50, 100),
+		}); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/dummystore/dummystore.go
+++ b/dummystore/dummystore.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/stratumn/go-indigocore/bufferedbatch"
 	"github.com/stratumn/go-indigocore/cs"
+	"github.com/stratumn/go-indigocore/monitoring"
 	"github.com/stratumn/go-indigocore/store"
 	"github.com/stratumn/go-indigocore/types"
 
@@ -88,9 +89,9 @@ func New(config *Config) *DummyStore {
 }
 
 // GetInfo implements github.com/stratumn/go-indigocore/store.Adapter.GetInfo.
-func (a *DummyStore) GetInfo(ctx context.Context) (interface{}, error) {
+func (a *DummyStore) GetInfo(ctx context.Context) (_ interface{}, err error) {
 	_, span := trace.StartSpan(ctx, "dummystore/GetInfo")
-	defer span.End()
+	defer monitoring.SetSpanStatusAndEnd(span, err)
 
 	return &Info{
 		Name:        Name,
@@ -108,9 +109,9 @@ func (a *DummyStore) AddStoreEventChannel(eventChan chan *store.Event) {
 /********** Store writer implementation **********/
 
 // CreateLink implements github.com/stratumn/go-indigocore/store.LinkWriter.CreateLink.
-func (a *DummyStore) CreateLink(ctx context.Context, link *cs.Link) (*types.Bytes32, error) {
+func (a *DummyStore) CreateLink(ctx context.Context, link *cs.Link) (_ *types.Bytes32, err error) {
 	_, span := trace.StartSpan(ctx, "dummystore/CreateLink")
-	defer span.End()
+	defer monitoring.SetSpanStatusAndEnd(span, err)
 
 	a.mutex.Lock()
 	defer a.mutex.Unlock()
@@ -145,9 +146,9 @@ func (a *DummyStore) createLink(link *cs.Link) (*types.Bytes32, error) {
 }
 
 // AddEvidence implements github.com/stratumn/go-indigocore/store.EvidenceWriter.AddEvidence.
-func (a *DummyStore) AddEvidence(ctx context.Context, linkHash *types.Bytes32, evidence *cs.Evidence) error {
+func (a *DummyStore) AddEvidence(ctx context.Context, linkHash *types.Bytes32, evidence *cs.Evidence) (err error) {
 	_, span := trace.StartSpan(ctx, "dummystore/AddEvidence")
-	defer span.End()
+	defer monitoring.SetSpanStatusAndEnd(span, err)
 
 	a.mutex.Lock()
 	defer a.mutex.Unlock()
@@ -184,9 +185,9 @@ func (a *DummyStore) addEvidence(linkHash string, evidence *cs.Evidence) error {
 /********** Store reader implementation **********/
 
 // GetSegment implements github.com/stratumn/go-indigocore/store.Adapter.GetSegment.
-func (a *DummyStore) GetSegment(ctx context.Context, linkHash *types.Bytes32) (*cs.Segment, error) {
+func (a *DummyStore) GetSegment(ctx context.Context, linkHash *types.Bytes32) (_ *cs.Segment, err error) {
 	_, span := trace.StartSpan(ctx, "dummystore/GetSegment")
-	defer span.End()
+	defer monitoring.SetSpanStatusAndEnd(span, err)
 
 	a.mutex.RLock()
 	defer a.mutex.RUnlock()
@@ -218,9 +219,9 @@ func (a *DummyStore) getSegment(linkHash string) (*cs.Segment, error) {
 }
 
 // FindSegments implements github.com/stratumn/go-indigocore/store.Adapter.FindSegments.
-func (a *DummyStore) FindSegments(ctx context.Context, filter *store.SegmentFilter) (cs.SegmentSlice, error) {
+func (a *DummyStore) FindSegments(ctx context.Context, filter *store.SegmentFilter) (_ cs.SegmentSlice, err error) {
 	_, span := trace.StartSpan(ctx, "dummystore/FindSegments")
-	defer span.End()
+	defer monitoring.SetSpanStatusAndEnd(span, err)
 
 	a.mutex.RLock()
 	defer a.mutex.RUnlock()
@@ -246,9 +247,9 @@ func (a *DummyStore) FindSegments(ctx context.Context, filter *store.SegmentFilt
 }
 
 // GetMapIDs implements github.com/stratumn/go-indigocore/store.Adapter.GetMapIDs.
-func (a *DummyStore) GetMapIDs(ctx context.Context, filter *store.MapFilter) ([]string, error) {
+func (a *DummyStore) GetMapIDs(ctx context.Context, filter *store.MapFilter) (_ []string, err error) {
 	_, span := trace.StartSpan(ctx, "dummystore/GetMapIDs")
-	defer span.End()
+	defer monitoring.SetSpanStatusAndEnd(span, err)
 
 	a.mutex.RLock()
 	defer a.mutex.RUnlock()
@@ -268,9 +269,9 @@ func (a *DummyStore) GetMapIDs(ctx context.Context, filter *store.MapFilter) ([]
 }
 
 // GetEvidences implements github.com/stratumn/go-indigocore/store.EvidenceReader.GetEvidences.
-func (a *DummyStore) GetEvidences(ctx context.Context, linkHash *types.Bytes32) (*cs.Evidences, error) {
+func (a *DummyStore) GetEvidences(ctx context.Context, linkHash *types.Bytes32) (_ *cs.Evidences, err error) {
 	_, span := trace.StartSpan(ctx, "dummystore/GetEvidences")
-	defer span.End()
+	defer monitoring.SetSpanStatusAndEnd(span, err)
 
 	a.mutex.RLock()
 	defer a.mutex.RUnlock()
@@ -282,9 +283,9 @@ func (a *DummyStore) GetEvidences(ctx context.Context, linkHash *types.Bytes32) 
 /********** github.com/stratumn/go-indigocore/store.KeyValueStore implementation **********/
 
 // GetValue implements github.com/stratumn/go-indigocore/store.KeyValueStore.GetValue.
-func (a *DummyStore) GetValue(ctx context.Context, key []byte) ([]byte, error) {
+func (a *DummyStore) GetValue(ctx context.Context, key []byte) (_ []byte, err error) {
 	_, span := trace.StartSpan(ctx, "dummystore/GetValue")
-	defer span.End()
+	defer monitoring.SetSpanStatusAndEnd(span, err)
 
 	a.mutex.RLock()
 	defer a.mutex.RUnlock()
@@ -293,9 +294,9 @@ func (a *DummyStore) GetValue(ctx context.Context, key []byte) ([]byte, error) {
 }
 
 // SetValue implements github.com/stratumn/go-indigocore/store.KeyValueStore.SetValue.
-func (a *DummyStore) SetValue(ctx context.Context, key, value []byte) error {
+func (a *DummyStore) SetValue(ctx context.Context, key, value []byte) (err error) {
 	_, span := trace.StartSpan(ctx, "dummystore/SetValue")
-	defer span.End()
+	defer monitoring.SetSpanStatusAndEnd(span, err)
 
 	a.mutex.Lock()
 	defer a.mutex.Unlock()
@@ -311,9 +312,9 @@ func (a *DummyStore) setValue(key, value []byte) error {
 }
 
 // DeleteValue implements github.com/stratumn/go-indigocore/store.KeyValueStore.DeleteValue.
-func (a *DummyStore) DeleteValue(ctx context.Context, key []byte) ([]byte, error) {
+func (a *DummyStore) DeleteValue(ctx context.Context, key []byte) (_ []byte, err error) {
 	_, span := trace.StartSpan(ctx, "dummystore/DeleteValue")
-	defer span.End()
+	defer monitoring.SetSpanStatusAndEnd(span, err)
 
 	a.mutex.Lock()
 	defer a.mutex.Unlock()
@@ -338,7 +339,7 @@ func (a *DummyStore) deleteValue(key []byte) ([]byte, error) {
 
 // NewBatch implements github.com/stratumn/go-indigocore/store.Adapter.NewBatch.
 func (a *DummyStore) NewBatch(ctx context.Context) (store.Batch, error) {
-	return bufferedbatch.NewBatch(a), nil
+	return bufferedbatch.NewBatch(ctx, a), nil
 }
 
 /********** Utilities **********/

--- a/elasticsearchstore/cmd.go
+++ b/elasticsearchstore/cmd.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/olivere/elastic"
-
 	log "github.com/sirupsen/logrus"
 	"github.com/stratumn/go-indigocore/utils"
 )
@@ -83,5 +82,4 @@ func RegisterFlags() {
 func InitializeWithFlags(version, commit string) *ESStore {
 	config := &Config{URL: url, Version: version, Commit: commit, Sniffing: sniffing, LogLevel: logLevel}
 	return Initialize(config)
-
 }

--- a/elasticsearchstore/elasticsearchstore.go
+++ b/elasticsearchstore/elasticsearchstore.go
@@ -22,6 +22,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/stratumn/go-indigocore/bufferedbatch"
 	"github.com/stratumn/go-indigocore/cs"
+	"github.com/stratumn/go-indigocore/monitoring"
 	"github.com/stratumn/go-indigocore/store"
 	"github.com/stratumn/go-indigocore/types"
 	"go.opencensus.io/trace"
@@ -138,9 +139,9 @@ func New(config *Config) (*ESStore, error) {
 /********** Store adapter implementation **********/
 
 // GetInfo implements github.com/stratumn/go-indigocore/store.Adapter.GetInfo.
-func (es *ESStore) GetInfo(ctx context.Context) (interface{}, error) {
+func (es *ESStore) GetInfo(ctx context.Context) (_ interface{}, err error) {
 	ctx, span := trace.StartSpan(ctx, "elasticsearchstore/GetInfo")
-	defer span.End()
+	defer monitoring.SetSpanStatusAndEnd(span, err)
 
 	return &Info{
 		Name:        Name,
@@ -163,9 +164,9 @@ func (es *ESStore) NewBatch(ctx context.Context) (store.Batch, error) {
 /********** Store writer implementation **********/
 
 // CreateLink implements github.com/stratumn/go-indigocore/store.LinkWriter.CreateLink.
-func (es *ESStore) CreateLink(ctx context.Context, link *cs.Link) (*types.Bytes32, error) {
+func (es *ESStore) CreateLink(ctx context.Context, link *cs.Link) (_ *types.Bytes32, err error) {
 	ctx, span := trace.StartSpan(ctx, "elasticsearchstore/CreateLink")
-	defer span.End()
+	defer monitoring.SetSpanStatusAndEnd(span, err)
 
 	linkHash, err := es.createLink(link)
 	if err != nil {
@@ -180,9 +181,9 @@ func (es *ESStore) CreateLink(ctx context.Context, link *cs.Link) (*types.Bytes3
 }
 
 // AddEvidence implements github.com/stratumn/go-indigocore/store.EvidenceWriter.AddEvidence.
-func (es *ESStore) AddEvidence(ctx context.Context, linkHash *types.Bytes32, evidence *cs.Evidence) error {
+func (es *ESStore) AddEvidence(ctx context.Context, linkHash *types.Bytes32, evidence *cs.Evidence) (err error) {
 	ctx, span := trace.StartSpan(ctx, "elasticsearchstore/AddEvidence")
-	defer span.End()
+	defer monitoring.SetSpanStatusAndEnd(span, err)
 
 	if err := es.addEvidence(linkHash.String(), evidence); err != nil {
 		return err
@@ -199,9 +200,9 @@ func (es *ESStore) AddEvidence(ctx context.Context, linkHash *types.Bytes32, evi
 /********** Store reader implementation **********/
 
 // GetSegment implements github.com/stratumn/go-indigocore/store.Adapter.GetSegment.
-func (es *ESStore) GetSegment(ctx context.Context, linkHash *types.Bytes32) (*cs.Segment, error) {
+func (es *ESStore) GetSegment(ctx context.Context, linkHash *types.Bytes32) (_ *cs.Segment, err error) {
 	ctx, span := trace.StartSpan(ctx, "elasticsearchstore/GetSegment")
-	defer span.End()
+	defer monitoring.SetSpanStatusAndEnd(span, err)
 
 	link, err := es.getLink(linkHash.String())
 	if err != nil || link == nil {
@@ -211,25 +212,25 @@ func (es *ESStore) GetSegment(ctx context.Context, linkHash *types.Bytes32) (*cs
 }
 
 // FindSegments implements github.com/stratumn/go-indigocore/store.Adapter.FindSegments.
-func (es *ESStore) FindSegments(ctx context.Context, filter *store.SegmentFilter) (cs.SegmentSlice, error) {
+func (es *ESStore) FindSegments(ctx context.Context, filter *store.SegmentFilter) (_ cs.SegmentSlice, err error) {
 	ctx, span := trace.StartSpan(ctx, "elasticsearchstore/FindSegments")
-	defer span.End()
+	defer monitoring.SetSpanStatusAndEnd(span, err)
 
 	return es.findSegments(filter)
 }
 
 // GetMapIDs implements github.com/stratumn/go-indigocore/store.Adapter.GetMapIDs.
-func (es *ESStore) GetMapIDs(ctx context.Context, filter *store.MapFilter) ([]string, error) {
+func (es *ESStore) GetMapIDs(ctx context.Context, filter *store.MapFilter) (_ []string, err error) {
 	ctx, span := trace.StartSpan(ctx, "elasticsearchstore/GetMapIDs")
-	defer span.End()
+	defer monitoring.SetSpanStatusAndEnd(span, err)
 
 	return es.getMapIDs(filter)
 }
 
 // GetEvidences implements github.com/stratumn/go-indigocore/store.EvidenceReader.GetEvidences.
-func (es *ESStore) GetEvidences(ctx context.Context, linkHash *types.Bytes32) (*cs.Evidences, error) {
+func (es *ESStore) GetEvidences(ctx context.Context, linkHash *types.Bytes32) (_ *cs.Evidences, err error) {
 	ctx, span := trace.StartSpan(ctx, "elasticsearchstore/GetEvidences")
-	defer span.End()
+	defer monitoring.SetSpanStatusAndEnd(span, err)
 
 	return es.getEvidences(linkHash.String())
 }
@@ -237,27 +238,27 @@ func (es *ESStore) GetEvidences(ctx context.Context, linkHash *types.Bytes32) (*
 /********** github.com/stratumn/go-indigocore/store.KeyValueStore implementation **********/
 
 // SetValue implements github.com/stratumn/go-indigocore/store.KeyValueStore.SetValue.
-func (es *ESStore) SetValue(ctx context.Context, key, value []byte) error {
+func (es *ESStore) SetValue(ctx context.Context, key, value []byte) (err error) {
 	ctx, span := trace.StartSpan(ctx, "elasticsearchstore/SetValue")
-	defer span.End()
+	defer monitoring.SetSpanStatusAndEnd(span, err)
 
 	hexKey := hex.EncodeToString(key)
 	return es.setValue(hexKey, value)
 }
 
 // GetValue implements github.com/stratumn/go-indigocore/store.Adapter.GetValue.
-func (es *ESStore) GetValue(ctx context.Context, key []byte) ([]byte, error) {
+func (es *ESStore) GetValue(ctx context.Context, key []byte) (_ []byte, err error) {
 	ctx, span := trace.StartSpan(ctx, "elasticsearchstore/GetValue")
-	defer span.End()
+	defer monitoring.SetSpanStatusAndEnd(span, err)
 
 	hexKey := hex.EncodeToString(key)
 	return es.getValue(hexKey)
 }
 
 // DeleteValue implements github.com/stratumn/go-indigocore/store.Adapter.DeleteValue.
-func (es *ESStore) DeleteValue(ctx context.Context, key []byte) ([]byte, error) {
+func (es *ESStore) DeleteValue(ctx context.Context, key []byte) (_ []byte, err error) {
 	ctx, span := trace.StartSpan(ctx, "elasticsearchstore/DeleteValue")
-	defer span.End()
+	defer monitoring.SetSpanStatusAndEnd(span, err)
 
 	hexKey := hex.EncodeToString(key)
 	return es.deleteValue(hexKey)

--- a/elasticsearchstore/elasticsearchstore.go
+++ b/elasticsearchstore/elasticsearchstore.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stratumn/go-indigocore/cs"
 	"github.com/stratumn/go-indigocore/store"
 	"github.com/stratumn/go-indigocore/types"
+	"go.opencensus.io/trace"
 )
 
 const (
@@ -138,6 +139,9 @@ func New(config *Config) (*ESStore, error) {
 
 // GetInfo implements github.com/stratumn/go-indigocore/store.Adapter.GetInfo.
 func (es *ESStore) GetInfo(ctx context.Context) (interface{}, error) {
+	ctx, span := trace.StartSpan(ctx, "elasticsearchstore/GetInfo")
+	defer span.End()
+
 	return &Info{
 		Name:        Name,
 		Description: Description,
@@ -153,13 +157,16 @@ func (es *ESStore) AddStoreEventChannel(eventChan chan *store.Event) {
 
 // NewBatch implements github.com/stratumn/go-indigocore/store.Adapter.NewBatch.
 func (es *ESStore) NewBatch(ctx context.Context) (store.Batch, error) {
-	return bufferedbatch.NewBatch(es), nil
+	return bufferedbatch.NewBatch(ctx, es), nil
 }
 
 /********** Store writer implementation **********/
 
 // CreateLink implements github.com/stratumn/go-indigocore/store.LinkWriter.CreateLink.
 func (es *ESStore) CreateLink(ctx context.Context, link *cs.Link) (*types.Bytes32, error) {
+	ctx, span := trace.StartSpan(ctx, "elasticsearchstore/CreateLink")
+	defer span.End()
+
 	linkHash, err := es.createLink(link)
 	if err != nil {
 		return nil, err
@@ -174,6 +181,9 @@ func (es *ESStore) CreateLink(ctx context.Context, link *cs.Link) (*types.Bytes3
 
 // AddEvidence implements github.com/stratumn/go-indigocore/store.EvidenceWriter.AddEvidence.
 func (es *ESStore) AddEvidence(ctx context.Context, linkHash *types.Bytes32, evidence *cs.Evidence) error {
+	ctx, span := trace.StartSpan(ctx, "elasticsearchstore/AddEvidence")
+	defer span.End()
+
 	if err := es.addEvidence(linkHash.String(), evidence); err != nil {
 		return err
 	}
@@ -190,6 +200,9 @@ func (es *ESStore) AddEvidence(ctx context.Context, linkHash *types.Bytes32, evi
 
 // GetSegment implements github.com/stratumn/go-indigocore/store.Adapter.GetSegment.
 func (es *ESStore) GetSegment(ctx context.Context, linkHash *types.Bytes32) (*cs.Segment, error) {
+	ctx, span := trace.StartSpan(ctx, "elasticsearchstore/GetSegment")
+	defer span.End()
+
 	link, err := es.getLink(linkHash.String())
 	if err != nil || link == nil {
 		return nil, err
@@ -199,16 +212,25 @@ func (es *ESStore) GetSegment(ctx context.Context, linkHash *types.Bytes32) (*cs
 
 // FindSegments implements github.com/stratumn/go-indigocore/store.Adapter.FindSegments.
 func (es *ESStore) FindSegments(ctx context.Context, filter *store.SegmentFilter) (cs.SegmentSlice, error) {
+	ctx, span := trace.StartSpan(ctx, "elasticsearchstore/FindSegments")
+	defer span.End()
+
 	return es.findSegments(filter)
 }
 
 // GetMapIDs implements github.com/stratumn/go-indigocore/store.Adapter.GetMapIDs.
 func (es *ESStore) GetMapIDs(ctx context.Context, filter *store.MapFilter) ([]string, error) {
+	ctx, span := trace.StartSpan(ctx, "elasticsearchstore/GetMapIDs")
+	defer span.End()
+
 	return es.getMapIDs(filter)
 }
 
 // GetEvidences implements github.com/stratumn/go-indigocore/store.EvidenceReader.GetEvidences.
 func (es *ESStore) GetEvidences(ctx context.Context, linkHash *types.Bytes32) (*cs.Evidences, error) {
+	ctx, span := trace.StartSpan(ctx, "elasticsearchstore/GetEvidences")
+	defer span.End()
+
 	return es.getEvidences(linkHash.String())
 }
 
@@ -216,18 +238,27 @@ func (es *ESStore) GetEvidences(ctx context.Context, linkHash *types.Bytes32) (*
 
 // SetValue implements github.com/stratumn/go-indigocore/store.KeyValueStore.SetValue.
 func (es *ESStore) SetValue(ctx context.Context, key, value []byte) error {
+	ctx, span := trace.StartSpan(ctx, "elasticsearchstore/SetValue")
+	defer span.End()
+
 	hexKey := hex.EncodeToString(key)
 	return es.setValue(hexKey, value)
 }
 
 // GetValue implements github.com/stratumn/go-indigocore/store.Adapter.GetValue.
 func (es *ESStore) GetValue(ctx context.Context, key []byte) ([]byte, error) {
+	ctx, span := trace.StartSpan(ctx, "elasticsearchstore/GetValue")
+	defer span.End()
+
 	hexKey := hex.EncodeToString(key)
 	return es.getValue(hexKey)
 }
 
 // DeleteValue implements github.com/stratumn/go-indigocore/store.Adapter.DeleteValue.
 func (es *ESStore) DeleteValue(ctx context.Context, key []byte) ([]byte, error) {
+	ctx, span := trace.StartSpan(ctx, "elasticsearchstore/DeleteValue")
+	defer span.End()
+
 	hexKey := hex.EncodeToString(key)
 	return es.deleteValue(hexKey)
 

--- a/filestore/batch.go
+++ b/filestore/batch.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"github.com/stratumn/go-indigocore/bufferedbatch"
+	"github.com/stratumn/go-indigocore/monitoring"
 	"go.opencensus.io/trace"
 )
 
@@ -39,7 +40,7 @@ func NewBatch(ctx context.Context, a *FileStore) *Batch {
 // Write implements github.com/stratumn/go-indigocore/store.Batch.Write
 func (b *Batch) Write(ctx context.Context) (err error) {
 	ctx, span := trace.StartSpan(ctx, "filestore/batch/Write")
-	defer span.End()
+	defer monitoring.SetSpanStatusAndEnd(span, err)
 
 	b.originalFileStore.mutex.Lock()
 	defer b.originalFileStore.mutex.Unlock()

--- a/filestore/batch.go
+++ b/filestore/batch.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"github.com/stratumn/go-indigocore/bufferedbatch"
+	"go.opencensus.io/trace"
 )
 
 // Batch is the type that implements github.com/stratumn/go-indigocore/store.Batch.
@@ -28,15 +29,18 @@ type Batch struct {
 }
 
 // NewBatch creates a new Batch
-func NewBatch(a *FileStore) *Batch {
+func NewBatch(ctx context.Context, a *FileStore) *Batch {
 	return &Batch{
-		Batch:             bufferedbatch.NewBatch(a),
+		Batch:             bufferedbatch.NewBatch(ctx, a),
 		originalFileStore: a,
 	}
 }
 
 // Write implements github.com/stratumn/go-indigocore/store.Batch.Write
 func (b *Batch) Write(ctx context.Context) (err error) {
+	ctx, span := trace.StartSpan(ctx, "filestore/batch/Write")
+	defer span.End()
+
 	b.originalFileStore.mutex.Lock()
 	defer b.originalFileStore.mutex.Unlock()
 

--- a/filestore/filestore.go
+++ b/filestore/filestore.go
@@ -37,6 +37,7 @@ import (
 	"github.com/stratumn/go-indigocore/leveldbstore"
 	"github.com/stratumn/go-indigocore/store"
 	"github.com/stratumn/go-indigocore/types"
+	"go.opencensus.io/trace"
 )
 
 const (
@@ -95,6 +96,9 @@ func New(config *Config) (*FileStore, error) {
 
 // GetInfo implements github.com/stratumn/go-indigocore/store.Adapter.GetInfo.
 func (a *FileStore) GetInfo(ctx context.Context) (interface{}, error) {
+	ctx, span := trace.StartSpan(ctx, "filestore/GetInfo")
+	defer span.End()
+
 	return &Info{
 		Name:        Name,
 		Description: Description,
@@ -110,13 +114,16 @@ func (a *FileStore) AddStoreEventChannel(eventChan chan *store.Event) {
 
 // NewBatch implements github.com/stratumn/go-indigocore/store.Adapter.NewBatch.
 func (a *FileStore) NewBatch(ctx context.Context) (store.Batch, error) {
-	return NewBatch(a), nil
+	return NewBatch(ctx, a), nil
 }
 
 /********** Store writer implementation **********/
 
 // CreateLink implements github.com/stratumn/go-indigocore/store.LinkWriter.CreateLink.
 func (a *FileStore) CreateLink(ctx context.Context, link *cs.Link) (*types.Bytes32, error) {
+	ctx, span := trace.StartSpan(ctx, "filestore/CreateLink")
+	defer span.End()
+
 	a.mutex.Lock()
 	defer a.mutex.Unlock()
 
@@ -155,6 +162,9 @@ func (a *FileStore) createLink(link *cs.Link) (*types.Bytes32, error) {
 
 // AddEvidence implements github.com/stratumn/go-indigocore/store.EvidenceWriter.AddEvidence.
 func (a *FileStore) AddEvidence(ctx context.Context, linkHash *types.Bytes32, evidence *cs.Evidence) error {
+	ctx, span := trace.StartSpan(ctx, "filestore/AddEvidence")
+	defer span.End()
+
 	currentEvidences, err := a.GetEvidences(ctx, linkHash)
 	if err != nil {
 		return err
@@ -188,6 +198,9 @@ func (a *FileStore) AddEvidence(ctx context.Context, linkHash *types.Bytes32, ev
 
 // GetSegment implements github.com/stratumn/go-indigocore/store.SegmentReader.GetSegment.
 func (a *FileStore) GetSegment(ctx context.Context, linkHash *types.Bytes32) (*cs.Segment, error) {
+	ctx, span := trace.StartSpan(ctx, "filestore/GetSegment")
+	defer span.End()
+
 	a.mutex.RLock()
 	defer a.mutex.RUnlock()
 
@@ -216,6 +229,9 @@ func (a *FileStore) getSegment(ctx context.Context, linkHash *types.Bytes32) (*c
 
 // FindSegments implements github.com/stratumn/go-indigocore/store.SegmentReader.FindSegments.
 func (a *FileStore) FindSegments(ctx context.Context, filter *store.SegmentFilter) (cs.SegmentSlice, error) {
+	ctx, span := trace.StartSpan(ctx, "filestore/FindSegments")
+	defer span.End()
+
 	var segments cs.SegmentSlice
 
 	a.forEach(ctx, func(segment *cs.Segment) error {
@@ -232,6 +248,9 @@ func (a *FileStore) FindSegments(ctx context.Context, filter *store.SegmentFilte
 
 // GetMapIDs implements github.com/stratumn/go-indigocore/store.SegmentReader.GetMapIDs.
 func (a *FileStore) GetMapIDs(ctx context.Context, filter *store.MapFilter) ([]string, error) {
+	ctx, span := trace.StartSpan(ctx, "filestore/GetMapIDs")
+	defer span.End()
+
 	set := map[string]struct{}{}
 	a.forEach(ctx, func(segment *cs.Segment) error {
 		if filter.Match(segment) {
@@ -251,6 +270,9 @@ func (a *FileStore) GetMapIDs(ctx context.Context, filter *store.MapFilter) ([]s
 
 // GetEvidences implements github.com/stratumn/go-indigocore/store.EvidenceReader.GetEvidences.
 func (a *FileStore) GetEvidences(ctx context.Context, linkHash *types.Bytes32) (*cs.Evidences, error) {
+	ctx, span := trace.StartSpan(ctx, "filestore/GetEvidences")
+	defer span.End()
+
 	key := getEvidenceKey(linkHash)
 	evidencesData, err := a.GetValue(ctx, key)
 	if err != nil {
@@ -294,16 +316,25 @@ func (a *FileStore) getLink(linkHash *types.Bytes32) (*cs.Link, error) {
 
 // SetValue implements github.com/stratumn/go-indigocore/store.KeyValueStore.SetValue.
 func (a *FileStore) SetValue(ctx context.Context, key []byte, value []byte) error {
+	ctx, span := trace.StartSpan(ctx, "filestore/SetValue")
+	defer span.End()
+
 	return a.kvDB.SetValue(ctx, key, value)
 }
 
 // GetValue implements github.com/stratumn/go-indigocore/store.KeyValueStore.GetValue.
 func (a *FileStore) GetValue(ctx context.Context, key []byte) ([]byte, error) {
+	ctx, span := trace.StartSpan(ctx, "filestore/GetValue")
+	defer span.End()
+
 	return a.kvDB.GetValue(ctx, key)
 }
 
 // DeleteValue implements github.com/stratumn/go-indigocore/store.KeyValueStore.DeleteValue.
 func (a *FileStore) DeleteValue(ctx context.Context, key []byte) ([]byte, error) {
+	ctx, span := trace.StartSpan(ctx, "filestore/DeleteValue")
+	defer span.End()
+
 	return a.kvDB.DeleteValue(ctx, key)
 }
 

--- a/filestore/filestore.go
+++ b/filestore/filestore.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/stratumn/go-indigocore/cs"
 	"github.com/stratumn/go-indigocore/leveldbstore"
+	"github.com/stratumn/go-indigocore/monitoring"
 	"github.com/stratumn/go-indigocore/store"
 	"github.com/stratumn/go-indigocore/types"
 	"go.opencensus.io/trace"
@@ -95,9 +96,9 @@ func New(config *Config) (*FileStore, error) {
 /********** Store adapter implementation **********/
 
 // GetInfo implements github.com/stratumn/go-indigocore/store.Adapter.GetInfo.
-func (a *FileStore) GetInfo(ctx context.Context) (interface{}, error) {
+func (a *FileStore) GetInfo(ctx context.Context) (_ interface{}, err error) {
 	ctx, span := trace.StartSpan(ctx, "filestore/GetInfo")
-	defer span.End()
+	defer monitoring.SetSpanStatusAndEnd(span, err)
 
 	return &Info{
 		Name:        Name,
@@ -120,9 +121,9 @@ func (a *FileStore) NewBatch(ctx context.Context) (store.Batch, error) {
 /********** Store writer implementation **********/
 
 // CreateLink implements github.com/stratumn/go-indigocore/store.LinkWriter.CreateLink.
-func (a *FileStore) CreateLink(ctx context.Context, link *cs.Link) (*types.Bytes32, error) {
+func (a *FileStore) CreateLink(ctx context.Context, link *cs.Link) (_ *types.Bytes32, err error) {
 	ctx, span := trace.StartSpan(ctx, "filestore/CreateLink")
-	defer span.End()
+	defer monitoring.SetSpanStatusAndEnd(span, err)
 
 	a.mutex.Lock()
 	defer a.mutex.Unlock()
@@ -161,9 +162,9 @@ func (a *FileStore) createLink(link *cs.Link) (*types.Bytes32, error) {
 }
 
 // AddEvidence implements github.com/stratumn/go-indigocore/store.EvidenceWriter.AddEvidence.
-func (a *FileStore) AddEvidence(ctx context.Context, linkHash *types.Bytes32, evidence *cs.Evidence) error {
+func (a *FileStore) AddEvidence(ctx context.Context, linkHash *types.Bytes32, evidence *cs.Evidence) (err error) {
 	ctx, span := trace.StartSpan(ctx, "filestore/AddEvidence")
-	defer span.End()
+	defer monitoring.SetSpanStatusAndEnd(span, err)
 
 	currentEvidences, err := a.GetEvidences(ctx, linkHash)
 	if err != nil {
@@ -197,9 +198,9 @@ func (a *FileStore) AddEvidence(ctx context.Context, linkHash *types.Bytes32, ev
 /********** Store reader implementation **********/
 
 // GetSegment implements github.com/stratumn/go-indigocore/store.SegmentReader.GetSegment.
-func (a *FileStore) GetSegment(ctx context.Context, linkHash *types.Bytes32) (*cs.Segment, error) {
+func (a *FileStore) GetSegment(ctx context.Context, linkHash *types.Bytes32) (_ *cs.Segment, err error) {
 	ctx, span := trace.StartSpan(ctx, "filestore/GetSegment")
-	defer span.End()
+	defer monitoring.SetSpanStatusAndEnd(span, err)
 
 	a.mutex.RLock()
 	defer a.mutex.RUnlock()
@@ -207,7 +208,7 @@ func (a *FileStore) GetSegment(ctx context.Context, linkHash *types.Bytes32) (*c
 	return a.getSegment(ctx, linkHash)
 }
 
-func (a *FileStore) getSegment(ctx context.Context, linkHash *types.Bytes32) (*cs.Segment, error) {
+func (a *FileStore) getSegment(ctx context.Context, linkHash *types.Bytes32) (_ *cs.Segment, err error) {
 	link, err := a.getLink(linkHash)
 	if err != nil || link == nil {
 		return nil, err
@@ -228,9 +229,9 @@ func (a *FileStore) getSegment(ctx context.Context, linkHash *types.Bytes32) (*c
 }
 
 // FindSegments implements github.com/stratumn/go-indigocore/store.SegmentReader.FindSegments.
-func (a *FileStore) FindSegments(ctx context.Context, filter *store.SegmentFilter) (cs.SegmentSlice, error) {
+func (a *FileStore) FindSegments(ctx context.Context, filter *store.SegmentFilter) (_ cs.SegmentSlice, err error) {
 	ctx, span := trace.StartSpan(ctx, "filestore/FindSegments")
-	defer span.End()
+	defer monitoring.SetSpanStatusAndEnd(span, err)
 
 	var segments cs.SegmentSlice
 
@@ -247,9 +248,9 @@ func (a *FileStore) FindSegments(ctx context.Context, filter *store.SegmentFilte
 }
 
 // GetMapIDs implements github.com/stratumn/go-indigocore/store.SegmentReader.GetMapIDs.
-func (a *FileStore) GetMapIDs(ctx context.Context, filter *store.MapFilter) ([]string, error) {
+func (a *FileStore) GetMapIDs(ctx context.Context, filter *store.MapFilter) (_ []string, err error) {
 	ctx, span := trace.StartSpan(ctx, "filestore/GetMapIDs")
-	defer span.End()
+	defer monitoring.SetSpanStatusAndEnd(span, err)
 
 	set := map[string]struct{}{}
 	a.forEach(ctx, func(segment *cs.Segment) error {
@@ -269,9 +270,9 @@ func (a *FileStore) GetMapIDs(ctx context.Context, filter *store.MapFilter) ([]s
 }
 
 // GetEvidences implements github.com/stratumn/go-indigocore/store.EvidenceReader.GetEvidences.
-func (a *FileStore) GetEvidences(ctx context.Context, linkHash *types.Bytes32) (*cs.Evidences, error) {
+func (a *FileStore) GetEvidences(ctx context.Context, linkHash *types.Bytes32) (_ *cs.Evidences, err error) {
 	ctx, span := trace.StartSpan(ctx, "filestore/GetEvidences")
-	defer span.End()
+	defer monitoring.SetSpanStatusAndEnd(span, err)
 
 	key := getEvidenceKey(linkHash)
 	evidencesData, err := a.GetValue(ctx, key)
@@ -315,25 +316,25 @@ func (a *FileStore) getLink(linkHash *types.Bytes32) (*cs.Link, error) {
 /********** github.com/stratumn/go-indigocore/store.KeyValueStore implementation **********/
 
 // SetValue implements github.com/stratumn/go-indigocore/store.KeyValueStore.SetValue.
-func (a *FileStore) SetValue(ctx context.Context, key []byte, value []byte) error {
+func (a *FileStore) SetValue(ctx context.Context, key []byte, value []byte) (err error) {
 	ctx, span := trace.StartSpan(ctx, "filestore/SetValue")
-	defer span.End()
+	defer monitoring.SetSpanStatusAndEnd(span, err)
 
 	return a.kvDB.SetValue(ctx, key, value)
 }
 
 // GetValue implements github.com/stratumn/go-indigocore/store.KeyValueStore.GetValue.
-func (a *FileStore) GetValue(ctx context.Context, key []byte) ([]byte, error) {
+func (a *FileStore) GetValue(ctx context.Context, key []byte) (_ []byte, err error) {
 	ctx, span := trace.StartSpan(ctx, "filestore/GetValue")
-	defer span.End()
+	defer monitoring.SetSpanStatusAndEnd(span, err)
 
 	return a.kvDB.GetValue(ctx, key)
 }
 
 // DeleteValue implements github.com/stratumn/go-indigocore/store.KeyValueStore.DeleteValue.
-func (a *FileStore) DeleteValue(ctx context.Context, key []byte) ([]byte, error) {
+func (a *FileStore) DeleteValue(ctx context.Context, key []byte) (_ []byte, err error) {
 	ctx, span := trace.StartSpan(ctx, "filestore/DeleteValue")
-	defer span.End()
+	defer monitoring.SetSpanStatusAndEnd(span, err)
 
 	return a.kvDB.DeleteValue(ctx, key)
 }

--- a/jsonhttp/jsonhttp.go
+++ b/jsonhttp/jsonhttp.go
@@ -86,7 +86,7 @@ func New(config *Config) *Server {
 	router.NotFound = notFoundHandler{config, NotFound}.ServeHTTP
 	server := &http.Server{
 		Addr:           config.Address,
-		Handler:        &ochttp.Handler{Handler: router},
+		Handler:        &ochttp.Handler{Handler: router, IsPublicEndpoint: true},
 		ReadTimeout:    config.ReadTimeout,
 		WriteTimeout:   config.WriteTimeout,
 		MaxHeaderBytes: config.MaxHeaderBytes,

--- a/leveldbstore/leveldbstore.go
+++ b/leveldbstore/leveldbstore.go
@@ -19,6 +19,7 @@ package leveldbstore
 import (
 	"context"
 
+	"github.com/stratumn/go-indigocore/monitoring"
 	"github.com/tendermint/tmlibs/db"
 	"go.opencensus.io/trace"
 )
@@ -46,26 +47,26 @@ func New(config *Config) (*LevelDBStore, error) {
 }
 
 // SetValue implements github.com/stratumn/go-indigocore/store.KeyValueStore.SetValue.
-func (a *LevelDBStore) SetValue(ctx context.Context, key []byte, value []byte) error {
+func (a *LevelDBStore) SetValue(ctx context.Context, key []byte, value []byte) (err error) {
 	ctx, span := trace.StartSpan(ctx, "leveldbstore/SetValue")
-	defer span.End()
+	defer monitoring.SetSpanStatusAndEnd(span, err)
 
 	a.kvDB.Set(key, value)
 	return nil
 }
 
 // GetValue implements github.com/stratumn/go-indigocore/store.KeyValueStore.GetValue.
-func (a *LevelDBStore) GetValue(ctx context.Context, key []byte) ([]byte, error) {
+func (a *LevelDBStore) GetValue(ctx context.Context, key []byte) (_ []byte, err error) {
 	ctx, span := trace.StartSpan(ctx, "leveldbstore/GetValue")
-	defer span.End()
+	defer monitoring.SetSpanStatusAndEnd(span, err)
 
 	return a.kvDB.Get(key), nil
 }
 
 // DeleteValue implements github.com/stratumn/go-indigocore/store.KeyValueStore.DeleteValue.
-func (a *LevelDBStore) DeleteValue(ctx context.Context, key []byte) ([]byte, error) {
+func (a *LevelDBStore) DeleteValue(ctx context.Context, key []byte) (_ []byte, err error) {
 	ctx, span := trace.StartSpan(ctx, "leveldbstore/DeleteValue")
-	defer span.End()
+	defer monitoring.SetSpanStatusAndEnd(span, err)
 
 	v := a.kvDB.Get(key)
 

--- a/leveldbstore/leveldbstore.go
+++ b/leveldbstore/leveldbstore.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"github.com/tendermint/tmlibs/db"
+	"go.opencensus.io/trace"
 )
 
 // LevelDBStore implements github.com/stratumn/go-indigocore/store.KeyValueStore.
@@ -46,17 +47,26 @@ func New(config *Config) (*LevelDBStore, error) {
 
 // SetValue implements github.com/stratumn/go-indigocore/store.KeyValueStore.SetValue.
 func (a *LevelDBStore) SetValue(ctx context.Context, key []byte, value []byte) error {
+	ctx, span := trace.StartSpan(ctx, "leveldbstore/SetValue")
+	defer span.End()
+
 	a.kvDB.Set(key, value)
 	return nil
 }
 
 // GetValue implements github.com/stratumn/go-indigocore/store.KeyValueStore.GetValue.
 func (a *LevelDBStore) GetValue(ctx context.Context, key []byte) ([]byte, error) {
+	ctx, span := trace.StartSpan(ctx, "leveldbstore/GetValue")
+	defer span.End()
+
 	return a.kvDB.Get(key), nil
 }
 
 // DeleteValue implements github.com/stratumn/go-indigocore/store.KeyValueStore.DeleteValue.
 func (a *LevelDBStore) DeleteValue(ctx context.Context, key []byte) ([]byte, error) {
+	ctx, span := trace.StartSpan(ctx, "leveldbstore/DeleteValue")
+	defer span.End()
+
 	v := a.kvDB.Get(key)
 
 	if v != nil {

--- a/monitoring/errorcode.go
+++ b/monitoring/errorcode.go
@@ -14,6 +14,8 @@
 
 package monitoring
 
+import "go.opencensus.io/trace"
+
 // Taken from https://github.com/googleapis/googleapis/blob/master/google/rpc/code.proto
 // as recommended by the OpenCensus documentation.
 const (
@@ -170,3 +172,17 @@ const (
 	// HTTP Mapping: 500 Internal Server Error
 	DataLoss = 15
 )
+
+// SetSpanStatusAndEnd sets the status of the span depending on the error
+// and ends it. You should usually call defer SetSpanStatusAndEnd(span, err)
+// at the beginning of your function.
+func SetSpanStatusAndEnd(span *trace.Span, err error) {
+	if err != nil {
+		span.SetStatus(trace.Status{
+			Code:    Unknown,
+			Message: err.Error(),
+		})
+	}
+
+	span.End()
+}

--- a/postgresstore/batch.go
+++ b/postgresstore/batch.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"database/sql"
 
+	"github.com/stratumn/go-indigocore/monitoring"
 	"go.opencensus.io/trace"
 )
 
@@ -44,9 +45,9 @@ func NewBatch(tx *sql.Tx) (*Batch, error) {
 }
 
 // Write implements github.com/stratumn/go-indigocore/store.Batch.Write.
-func (b *Batch) Write(ctx context.Context) error {
+func (b *Batch) Write(ctx context.Context) (err error) {
 	ctx, span := trace.StartSpan(ctx, "postgresstore/batch/Write")
-	defer span.End()
+	defer monitoring.SetSpanStatusAndEnd(span, err)
 
 	b.done = true
 	return b.tx.Commit()

--- a/postgresstore/batch.go
+++ b/postgresstore/batch.go
@@ -17,6 +17,8 @@ package postgresstore
 import (
 	"context"
 	"database/sql"
+
+	"go.opencensus.io/trace"
 )
 
 // Batch is the type that implements github.com/stratumn/go-indigocore/store.Batch.
@@ -43,6 +45,9 @@ func NewBatch(tx *sql.Tx) (*Batch, error) {
 
 // Write implements github.com/stratumn/go-indigocore/store.Batch.Write.
 func (b *Batch) Write(ctx context.Context) error {
+	ctx, span := trace.StartSpan(ctx, "postgresstore/batch/Write")
+	defer span.End()
+
 	b.done = true
 	return b.tx.Commit()
 }

--- a/postgresstore/postgresstore.go
+++ b/postgresstore/postgresstore.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 
 	"github.com/stratumn/go-indigocore/cs"
+	"github.com/stratumn/go-indigocore/monitoring"
 	"github.com/stratumn/go-indigocore/store"
 	"github.com/stratumn/go-indigocore/types"
 	"go.opencensus.io/trace"
@@ -84,9 +85,9 @@ func New(config *Config) (*Store, error) {
 }
 
 // GetInfo implements github.com/stratumn/go-indigocore/store.Adapter.GetInfo.
-func (a *Store) GetInfo(ctx context.Context) (interface{}, error) {
+func (a *Store) GetInfo(ctx context.Context) (_ interface{}, err error) {
 	ctx, span := trace.StartSpan(ctx, "postgresstore/GetInfo")
-	defer span.End()
+	defer monitoring.SetSpanStatusAndEnd(span, err)
 
 	return &Info{
 		Name:        Name,
@@ -97,9 +98,9 @@ func (a *Store) GetInfo(ctx context.Context) (interface{}, error) {
 }
 
 // NewBatch implements github.com/stratumn/go-indigocore/store.Adapter.NewBatch.
-func (a *Store) NewBatch(ctx context.Context) (store.Batch, error) {
+func (a *Store) NewBatch(ctx context.Context) (_ store.Batch, err error) {
 	ctx, span := trace.StartSpan(ctx, "postgresstore/NewBatch")
-	defer span.End()
+	defer monitoring.SetSpanStatusAndEnd(span, err)
 
 	for b := range a.batches {
 		if b.done {
@@ -126,9 +127,9 @@ func (a *Store) AddStoreEventChannel(eventChan chan *store.Event) {
 }
 
 // CreateLink implements github.com/stratumn/go-indigocore/store.LinkWriter.CreateLink.
-func (a *Store) CreateLink(ctx context.Context, link *cs.Link) (*types.Bytes32, error) {
+func (a *Store) CreateLink(ctx context.Context, link *cs.Link) (_ *types.Bytes32, err error) {
 	ctx, span := trace.StartSpan(ctx, "postgresstore/CreateLink")
-	defer span.End()
+	defer monitoring.SetSpanStatusAndEnd(span, err)
 
 	linkHash, err := a.writer.CreateLink(ctx, link)
 	if err != nil {
@@ -144,9 +145,9 @@ func (a *Store) CreateLink(ctx context.Context, link *cs.Link) (*types.Bytes32, 
 }
 
 // AddEvidence implements github.com/stratumn/go-indigocore/store.EvidenceWriter.AddEvidence.
-func (a *Store) AddEvidence(ctx context.Context, linkHash *types.Bytes32, evidence *cs.Evidence) error {
+func (a *Store) AddEvidence(ctx context.Context, linkHash *types.Bytes32, evidence *cs.Evidence) (err error) {
 	ctx, span := trace.StartSpan(ctx, "postgresstore/AddEvidence")
-	defer span.End()
+	defer monitoring.SetSpanStatusAndEnd(span, err)
 
 	data, err := json.Marshal(evidence)
 	if err != nil {

--- a/postgresstore/postgresstore.go
+++ b/postgresstore/postgresstore.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stratumn/go-indigocore/cs"
 	"github.com/stratumn/go-indigocore/store"
 	"github.com/stratumn/go-indigocore/types"
+	"go.opencensus.io/trace"
 )
 
 const (
@@ -84,6 +85,9 @@ func New(config *Config) (*Store, error) {
 
 // GetInfo implements github.com/stratumn/go-indigocore/store.Adapter.GetInfo.
 func (a *Store) GetInfo(ctx context.Context) (interface{}, error) {
+	ctx, span := trace.StartSpan(ctx, "postgresstore/GetInfo")
+	defer span.End()
+
 	return &Info{
 		Name:        Name,
 		Description: Description,
@@ -94,6 +98,9 @@ func (a *Store) GetInfo(ctx context.Context) (interface{}, error) {
 
 // NewBatch implements github.com/stratumn/go-indigocore/store.Adapter.NewBatch.
 func (a *Store) NewBatch(ctx context.Context) (store.Batch, error) {
+	ctx, span := trace.StartSpan(ctx, "postgresstore/NewBatch")
+	defer span.End()
+
 	for b := range a.batches {
 		if b.done {
 			delete(a.batches, b)
@@ -120,6 +127,9 @@ func (a *Store) AddStoreEventChannel(eventChan chan *store.Event) {
 
 // CreateLink implements github.com/stratumn/go-indigocore/store.LinkWriter.CreateLink.
 func (a *Store) CreateLink(ctx context.Context, link *cs.Link) (*types.Bytes32, error) {
+	ctx, span := trace.StartSpan(ctx, "postgresstore/CreateLink")
+	defer span.End()
+
 	linkHash, err := a.writer.CreateLink(ctx, link)
 	if err != nil {
 		return nil, err
@@ -135,6 +145,9 @@ func (a *Store) CreateLink(ctx context.Context, link *cs.Link) (*types.Bytes32, 
 
 // AddEvidence implements github.com/stratumn/go-indigocore/store.EvidenceWriter.AddEvidence.
 func (a *Store) AddEvidence(ctx context.Context, linkHash *types.Bytes32, evidence *cs.Evidence) error {
+	ctx, span := trace.StartSpan(ctx, "postgresstore/AddEvidence")
+	defer span.End()
+
 	data, err := json.Marshal(evidence)
 	if err != nil {
 		return err

--- a/postgresstore/reader.go
+++ b/postgresstore/reader.go
@@ -24,6 +24,8 @@ import (
 	"github.com/stratumn/go-indigocore/cs"
 	"github.com/stratumn/go-indigocore/store"
 	"github.com/stratumn/go-indigocore/types"
+
+	"go.opencensus.io/trace"
 )
 
 type reader struct {
@@ -32,6 +34,9 @@ type reader struct {
 
 // GetSegment implements github.com/stratumn/go-indigocore/store.SegmentReader.GetSegment.
 func (a *reader) GetSegment(ctx context.Context, linkHash *types.Bytes32) (*cs.Segment, error) {
+	ctx, span := trace.StartSpan(ctx, "postgresstore/GetSegment")
+	defer span.End()
+
 	var segments = make(cs.SegmentSlice, 0, 1)
 
 	rows, err := a.stmts.GetSegment.Query(linkHash[:])
@@ -52,6 +57,9 @@ func (a *reader) GetSegment(ctx context.Context, linkHash *types.Bytes32) (*cs.S
 
 // FindSegments implements github.com/stratumn/go-indigocore/store.SegmentReader.FindSegments.
 func (a *reader) FindSegments(ctx context.Context, filter *store.SegmentFilter) (cs.SegmentSlice, error) {
+	ctx, span := trace.StartSpan(ctx, "postgresstore/FindSegments")
+	defer span.End()
+
 	var (
 		rows         *sql.Rows
 		err          error
@@ -182,6 +190,9 @@ func scanLinkAndEvidences(rows *sql.Rows, segments *cs.SegmentSlice) error {
 
 // GetMapIDs implements github.com/stratumn/go-indigocore/store.SegmentReader.GetMapIDs.
 func (a *reader) GetMapIDs(ctx context.Context, filter *store.MapFilter) ([]string, error) {
+	ctx, span := trace.StartSpan(ctx, "postgresstore/GetMapIDs")
+	defer span.End()
+
 	rows, err := a.stmts.GetMapIDs.Query(filter.Pagination.Offset, filter.Pagination.Limit, filter.Process)
 	if err != nil {
 		return nil, err
@@ -205,6 +216,9 @@ func (a *reader) GetMapIDs(ctx context.Context, filter *store.MapFilter) ([]stri
 
 // GetValue implements github.com/stratumn/go-indigocore/store.KeyValueStore.GetValue.
 func (a *reader) GetValue(ctx context.Context, key []byte) ([]byte, error) {
+	ctx, span := trace.StartSpan(ctx, "postgresstore/GetValue")
+	defer span.End()
+
 	var data []byte
 
 	if err := a.stmts.GetValue.QueryRow(key).Scan(&data); err != nil {
@@ -219,6 +233,9 @@ func (a *reader) GetValue(ctx context.Context, key []byte) ([]byte, error) {
 
 // GetEvidences implements github.com/stratumn/go-indigocore/store.EvidenceReader.GetEvidences.
 func (a *reader) GetEvidences(ctx context.Context, linkHash *types.Bytes32) (*cs.Evidences, error) {
+	ctx, span := trace.StartSpan(ctx, "postgresstore/GetEvidences")
+	defer span.End()
+
 	var evidences cs.Evidences
 
 	rows, err := a.stmts.GetEvidences.Query(linkHash[:])

--- a/postgresstore/reader.go
+++ b/postgresstore/reader.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/lib/pq"
 	"github.com/stratumn/go-indigocore/cs"
+	"github.com/stratumn/go-indigocore/monitoring"
 	"github.com/stratumn/go-indigocore/store"
 	"github.com/stratumn/go-indigocore/types"
 
@@ -33,9 +34,9 @@ type reader struct {
 }
 
 // GetSegment implements github.com/stratumn/go-indigocore/store.SegmentReader.GetSegment.
-func (a *reader) GetSegment(ctx context.Context, linkHash *types.Bytes32) (*cs.Segment, error) {
+func (a *reader) GetSegment(ctx context.Context, linkHash *types.Bytes32) (_ *cs.Segment, err error) {
 	ctx, span := trace.StartSpan(ctx, "postgresstore/GetSegment")
-	defer span.End()
+	defer monitoring.SetSpanStatusAndEnd(span, err)
 
 	var segments = make(cs.SegmentSlice, 0, 1)
 
@@ -56,13 +57,12 @@ func (a *reader) GetSegment(ctx context.Context, linkHash *types.Bytes32) (*cs.S
 }
 
 // FindSegments implements github.com/stratumn/go-indigocore/store.SegmentReader.FindSegments.
-func (a *reader) FindSegments(ctx context.Context, filter *store.SegmentFilter) (cs.SegmentSlice, error) {
+func (a *reader) FindSegments(ctx context.Context, filter *store.SegmentFilter) (_ cs.SegmentSlice, err error) {
 	ctx, span := trace.StartSpan(ctx, "postgresstore/FindSegments")
-	defer span.End()
+	defer monitoring.SetSpanStatusAndEnd(span, err)
 
 	var (
 		rows         *sql.Rows
-		err          error
 		limit        = filter.Limit
 		offset       = filter.Offset
 		segments     = make(cs.SegmentSlice, 0, limit)
@@ -189,9 +189,9 @@ func scanLinkAndEvidences(rows *sql.Rows, segments *cs.SegmentSlice) error {
 }
 
 // GetMapIDs implements github.com/stratumn/go-indigocore/store.SegmentReader.GetMapIDs.
-func (a *reader) GetMapIDs(ctx context.Context, filter *store.MapFilter) ([]string, error) {
+func (a *reader) GetMapIDs(ctx context.Context, filter *store.MapFilter) (_ []string, err error) {
 	ctx, span := trace.StartSpan(ctx, "postgresstore/GetMapIDs")
-	defer span.End()
+	defer monitoring.SetSpanStatusAndEnd(span, err)
 
 	rows, err := a.stmts.GetMapIDs.Query(filter.Pagination.Offset, filter.Pagination.Limit, filter.Process)
 	if err != nil {
@@ -215,9 +215,9 @@ func (a *reader) GetMapIDs(ctx context.Context, filter *store.MapFilter) ([]stri
 }
 
 // GetValue implements github.com/stratumn/go-indigocore/store.KeyValueStore.GetValue.
-func (a *reader) GetValue(ctx context.Context, key []byte) ([]byte, error) {
+func (a *reader) GetValue(ctx context.Context, key []byte) (_ []byte, err error) {
 	ctx, span := trace.StartSpan(ctx, "postgresstore/GetValue")
-	defer span.End()
+	defer monitoring.SetSpanStatusAndEnd(span, err)
 
 	var data []byte
 
@@ -232,9 +232,9 @@ func (a *reader) GetValue(ctx context.Context, key []byte) ([]byte, error) {
 }
 
 // GetEvidences implements github.com/stratumn/go-indigocore/store.EvidenceReader.GetEvidences.
-func (a *reader) GetEvidences(ctx context.Context, linkHash *types.Bytes32) (*cs.Evidences, error) {
+func (a *reader) GetEvidences(ctx context.Context, linkHash *types.Bytes32) (_ *cs.Evidences, err error) {
 	ctx, span := trace.StartSpan(ctx, "postgresstore/GetEvidences")
-	defer span.End()
+	defer monitoring.SetSpanStatusAndEnd(span, err)
 
 	var evidences cs.Evidences
 

--- a/postgresstore/writer.go
+++ b/postgresstore/writer.go
@@ -21,6 +21,8 @@ import (
 	"github.com/lib/pq"
 	"github.com/stratumn/go-indigocore/cs"
 	"github.com/stratumn/go-indigocore/types"
+
+	"go.opencensus.io/trace"
 )
 
 type writer struct {
@@ -29,6 +31,9 @@ type writer struct {
 
 // SetValue implements github.com/stratumn/go-indigocore/store.KeyValueStore.SetValue.
 func (a *writer) SetValue(ctx context.Context, key []byte, value []byte) error {
+	ctx, span := trace.StartSpan(ctx, "postgresstore/SetValue")
+	defer span.End()
+
 	_, err := a.stmts.SaveValue.Exec(key, value)
 	if err != nil {
 		return err
@@ -39,6 +44,9 @@ func (a *writer) SetValue(ctx context.Context, key []byte, value []byte) error {
 
 // DeleteValue implements github.com/stratumn/go-indigocore/store.KeyValueStore.DeleteValue.
 func (a *writer) DeleteValue(ctx context.Context, key []byte) ([]byte, error) {
+	ctx, span := trace.StartSpan(ctx, "postgresstore/DeleteValue")
+	defer span.End()
+
 	var data []byte
 
 	if err := a.stmts.DeleteValue.QueryRow(key).Scan(&data); err != nil {
@@ -53,6 +61,9 @@ func (a *writer) DeleteValue(ctx context.Context, key []byte) ([]byte, error) {
 
 // CreateLink implements github.com/stratumn/go-indigocore/store.Adapter.CreateLink.
 func (a *writer) CreateLink(ctx context.Context, link *cs.Link) (*types.Bytes32, error) {
+	ctx, span := trace.StartSpan(ctx, "postgresstore/CreateLink")
+	defer span.End()
+
 	var (
 		priority     = link.Meta.Priority
 		mapID        = link.Meta.MapID

--- a/postgresstore/writer.go
+++ b/postgresstore/writer.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/lib/pq"
 	"github.com/stratumn/go-indigocore/cs"
+	"github.com/stratumn/go-indigocore/monitoring"
 	"github.com/stratumn/go-indigocore/types"
 
 	"go.opencensus.io/trace"
@@ -30,22 +31,18 @@ type writer struct {
 }
 
 // SetValue implements github.com/stratumn/go-indigocore/store.KeyValueStore.SetValue.
-func (a *writer) SetValue(ctx context.Context, key []byte, value []byte) error {
+func (a *writer) SetValue(ctx context.Context, key []byte, value []byte) (err error) {
 	ctx, span := trace.StartSpan(ctx, "postgresstore/SetValue")
-	defer span.End()
+	defer monitoring.SetSpanStatusAndEnd(span, err)
 
-	_, err := a.stmts.SaveValue.Exec(key, value)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	_, err = a.stmts.SaveValue.Exec(key, value)
+	return
 }
 
 // DeleteValue implements github.com/stratumn/go-indigocore/store.KeyValueStore.DeleteValue.
-func (a *writer) DeleteValue(ctx context.Context, key []byte) ([]byte, error) {
+func (a *writer) DeleteValue(ctx context.Context, key []byte) (_ []byte, err error) {
 	ctx, span := trace.StartSpan(ctx, "postgresstore/DeleteValue")
-	defer span.End()
+	defer monitoring.SetSpanStatusAndEnd(span, err)
 
 	var data []byte
 
@@ -60,9 +57,9 @@ func (a *writer) DeleteValue(ctx context.Context, key []byte) ([]byte, error) {
 }
 
 // CreateLink implements github.com/stratumn/go-indigocore/store.Adapter.CreateLink.
-func (a *writer) CreateLink(ctx context.Context, link *cs.Link) (*types.Bytes32, error) {
+func (a *writer) CreateLink(ctx context.Context, link *cs.Link) (_ *types.Bytes32, err error) {
 	ctx, span := trace.StartSpan(ctx, "postgresstore/CreateLink")
-	defer span.End()
+	defer monitoring.SetSpanStatusAndEnd(span, err)
 
 	var (
 		priority     = link.Meta.Priority

--- a/rethinkstore/rethinkstore.go
+++ b/rethinkstore/rethinkstore.go
@@ -30,6 +30,8 @@ import (
 	"github.com/stratumn/go-indigocore/store"
 	"github.com/stratumn/go-indigocore/types"
 	"github.com/stratumn/go-indigocore/utils"
+	"go.opencensus.io/trace"
+
 	rethink "gopkg.in/dancannon/gorethink.v4"
 )
 
@@ -161,6 +163,9 @@ func (a *Store) AddStoreEventChannel(eventChan chan *store.Event) {
 
 // GetInfo implements github.com/stratumn/go-indigocore/store.Adapter.GetInfo.
 func (a *Store) GetInfo(ctx context.Context) (interface{}, error) {
+	ctx, span := trace.StartSpan(ctx, "rethinkstore/GetInfo")
+	defer span.End()
+
 	return &Info{
 		Name:        Name,
 		Description: Description,
@@ -187,6 +192,9 @@ func formatLink(link *cs.Link) {
 
 // CreateLink implements github.com/stratumn/go-indigocore/store.LinkWriter.CreateLink.
 func (a *Store) CreateLink(ctx context.Context, link *cs.Link) (*types.Bytes32, error) {
+	ctx, span := trace.StartSpan(ctx, "rethinkstore/CreateLink")
+	defer span.End()
+
 	prevLinkHash := link.Meta.GetPrevLinkHash()
 
 	formatLink(link)
@@ -225,6 +233,9 @@ func (a *Store) CreateLink(ctx context.Context, link *cs.Link) (*types.Bytes32, 
 
 // GetSegment implements github.com/stratumn/go-indigocore/store.SegmentReader.GetSegment.
 func (a *Store) GetSegment(ctx context.Context, linkHash *types.Bytes32) (*cs.Segment, error) {
+	ctx, span := trace.StartSpan(ctx, "rethinkstore/GetSegment")
+	defer span.End()
+
 	cur, err := a.links.Get(linkHash[:]).Run(a.session)
 
 	if err != nil {
@@ -250,6 +261,9 @@ func (a *Store) GetSegment(ctx context.Context, linkHash *types.Bytes32) (*cs.Se
 
 // FindSegments implements github.com/stratumn/go-indigocore/store.SegmentReader.FindSegments.
 func (a *Store) FindSegments(ctx context.Context, filter *store.SegmentFilter) (cs.SegmentSlice, error) {
+	ctx, span := trace.StartSpan(ctx, "rethinkstore/FindSegments")
+	defer span.End()
+
 	var prevLinkHash []byte
 	q := a.links
 
@@ -344,6 +358,9 @@ func (a *Store) FindSegments(ctx context.Context, filter *store.SegmentFilter) (
 
 // GetMapIDs implements github.com/stratumn/go-indigocore/store.SegmentReader.GetMapIDs.
 func (a *Store) GetMapIDs(ctx context.Context, filter *store.MapFilter) ([]string, error) {
+	ctx, span := trace.StartSpan(ctx, "rethinkstore/GetMapIDs")
+	defer span.End()
+
 	q := a.links
 	if process := filter.Process; len(process) > 0 {
 
@@ -387,6 +404,9 @@ func (a *Store) GetMapIDs(ctx context.Context, filter *store.MapFilter) ([]strin
 
 // AddEvidence implements github.com/stratumn/go-indigocore/store.EvidenceWriter.AddEvidence.
 func (a *Store) AddEvidence(ctx context.Context, linkHash *types.Bytes32, evidence *cs.Evidence) error {
+	ctx, span := trace.StartSpan(ctx, "rethinkstore/AddEvidence")
+	defer span.End()
+
 	cur, err := a.evidences.Get(linkHash).Run(a.session)
 	if err != nil {
 		return err
@@ -429,6 +449,9 @@ func (a *Store) AddEvidence(ctx context.Context, linkHash *types.Bytes32, eviden
 
 // GetEvidences implements github.com/stratumn/go-indigocore/store.EvidenceReader.GetEvidences.
 func (a *Store) GetEvidences(ctx context.Context, linkHash *types.Bytes32) (*cs.Evidences, error) {
+	ctx, span := trace.StartSpan(ctx, "rethinkstore/GetEvidences")
+	defer span.End()
+
 	cur, err := a.evidences.Get(linkHash).Run(a.session)
 	if err != nil {
 		return nil, err
@@ -447,6 +470,9 @@ func (a *Store) GetEvidences(ctx context.Context, linkHash *types.Bytes32) (*cs.
 
 // GetValue implements github.com/stratumn/go-indigocore/store.KeyValueStore.GetValue.
 func (a *Store) GetValue(ctx context.Context, key []byte) ([]byte, error) {
+	ctx, span := trace.StartSpan(ctx, "rethinkstore/GetValue")
+	defer span.End()
+
 	cur, err := a.values.Get(key).Run(a.session)
 	if err != nil {
 		return nil, err
@@ -466,6 +492,9 @@ func (a *Store) GetValue(ctx context.Context, key []byte) ([]byte, error) {
 
 // SetValue implements github.com/stratumn/go-indigocore/store.KeyValueStore.SetValue.
 func (a *Store) SetValue(ctx context.Context, key, value []byte) error {
+	ctx, span := trace.StartSpan(ctx, "rethinkstore/SetValue")
+	defer span.End()
+
 	v := &valueWrapper{
 		ID:    key,
 		Value: value,
@@ -476,6 +505,9 @@ func (a *Store) SetValue(ctx context.Context, key, value []byte) error {
 
 // DeleteValue implements github.com/stratumn/go-indigocore/store.KeyValueStore.DeleteValue.
 func (a *Store) DeleteValue(ctx context.Context, key []byte) ([]byte, error) {
+	ctx, span := trace.StartSpan(ctx, "rethinkstore/DeleteValue")
+	defer span.End()
+
 	res, err := a.values.
 		Get(key).
 		Delete(rethink.DeleteOpts{ReturnChanges: true}).
@@ -505,13 +537,16 @@ type rethinkBufferedBatch struct {
 
 // CreateLink implements github.com/stratumn/go-indigocore/store.LinkWriter.CreateLink.
 func (b *rethinkBufferedBatch) CreateLink(ctx context.Context, link *cs.Link) (*types.Bytes32, error) {
+	ctx, span := trace.StartSpan(ctx, "rethinkstore/CreateLink")
+	defer span.End()
+
 	formatLink(link)
 	return b.Batch.CreateLink(ctx, link)
 }
 
 // NewBatch implements github.com/stratumn/go-indigocore/store.Adapter.NewBatch.
 func (a *Store) NewBatch(ctx context.Context) (store.Batch, error) {
-	bbBatch := bufferedbatch.NewBatch(a)
+	bbBatch := bufferedbatch.NewBatch(ctx, a)
 	if bbBatch == nil {
 		return nil, errors.New("cannot create underlying batch")
 	}

--- a/rethinkstore/rethinkstore.go
+++ b/rethinkstore/rethinkstore.go
@@ -27,6 +27,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/stratumn/go-indigocore/bufferedbatch"
 	"github.com/stratumn/go-indigocore/cs"
+	"github.com/stratumn/go-indigocore/monitoring"
 	"github.com/stratumn/go-indigocore/store"
 	"github.com/stratumn/go-indigocore/types"
 	"github.com/stratumn/go-indigocore/utils"
@@ -162,9 +163,9 @@ func (a *Store) AddStoreEventChannel(eventChan chan *store.Event) {
 }
 
 // GetInfo implements github.com/stratumn/go-indigocore/store.Adapter.GetInfo.
-func (a *Store) GetInfo(ctx context.Context) (interface{}, error) {
+func (a *Store) GetInfo(ctx context.Context) (_ interface{}, err error) {
 	ctx, span := trace.StartSpan(ctx, "rethinkstore/GetInfo")
-	defer span.End()
+	defer monitoring.SetSpanStatusAndEnd(span, err)
 
 	return &Info{
 		Name:        Name,
@@ -191,9 +192,9 @@ func formatLink(link *cs.Link) {
 }
 
 // CreateLink implements github.com/stratumn/go-indigocore/store.LinkWriter.CreateLink.
-func (a *Store) CreateLink(ctx context.Context, link *cs.Link) (*types.Bytes32, error) {
+func (a *Store) CreateLink(ctx context.Context, link *cs.Link) (_ *types.Bytes32, err error) {
 	ctx, span := trace.StartSpan(ctx, "rethinkstore/CreateLink")
-	defer span.End()
+	defer monitoring.SetSpanStatusAndEnd(span, err)
 
 	prevLinkHash := link.Meta.GetPrevLinkHash()
 
@@ -232,9 +233,9 @@ func (a *Store) CreateLink(ctx context.Context, link *cs.Link) (*types.Bytes32, 
 }
 
 // GetSegment implements github.com/stratumn/go-indigocore/store.SegmentReader.GetSegment.
-func (a *Store) GetSegment(ctx context.Context, linkHash *types.Bytes32) (*cs.Segment, error) {
+func (a *Store) GetSegment(ctx context.Context, linkHash *types.Bytes32) (_ *cs.Segment, err error) {
 	ctx, span := trace.StartSpan(ctx, "rethinkstore/GetSegment")
-	defer span.End()
+	defer monitoring.SetSpanStatusAndEnd(span, err)
 
 	cur, err := a.links.Get(linkHash[:]).Run(a.session)
 
@@ -260,9 +261,9 @@ func (a *Store) GetSegment(ctx context.Context, linkHash *types.Bytes32) (*cs.Se
 }
 
 // FindSegments implements github.com/stratumn/go-indigocore/store.SegmentReader.FindSegments.
-func (a *Store) FindSegments(ctx context.Context, filter *store.SegmentFilter) (cs.SegmentSlice, error) {
+func (a *Store) FindSegments(ctx context.Context, filter *store.SegmentFilter) (_ cs.SegmentSlice, err error) {
 	ctx, span := trace.StartSpan(ctx, "rethinkstore/FindSegments")
-	defer span.End()
+	defer monitoring.SetSpanStatusAndEnd(span, err)
 
 	var prevLinkHash []byte
 	q := a.links
@@ -357,9 +358,9 @@ func (a *Store) FindSegments(ctx context.Context, filter *store.SegmentFilter) (
 }
 
 // GetMapIDs implements github.com/stratumn/go-indigocore/store.SegmentReader.GetMapIDs.
-func (a *Store) GetMapIDs(ctx context.Context, filter *store.MapFilter) ([]string, error) {
+func (a *Store) GetMapIDs(ctx context.Context, filter *store.MapFilter) (_ []string, err error) {
 	ctx, span := trace.StartSpan(ctx, "rethinkstore/GetMapIDs")
-	defer span.End()
+	defer monitoring.SetSpanStatusAndEnd(span, err)
 
 	q := a.links
 	if process := filter.Process; len(process) > 0 {
@@ -403,9 +404,9 @@ func (a *Store) GetMapIDs(ctx context.Context, filter *store.MapFilter) ([]strin
 }
 
 // AddEvidence implements github.com/stratumn/go-indigocore/store.EvidenceWriter.AddEvidence.
-func (a *Store) AddEvidence(ctx context.Context, linkHash *types.Bytes32, evidence *cs.Evidence) error {
+func (a *Store) AddEvidence(ctx context.Context, linkHash *types.Bytes32, evidence *cs.Evidence) (err error) {
 	ctx, span := trace.StartSpan(ctx, "rethinkstore/AddEvidence")
-	defer span.End()
+	defer monitoring.SetSpanStatusAndEnd(span, err)
 
 	cur, err := a.evidences.Get(linkHash).Run(a.session)
 	if err != nil {
@@ -448,9 +449,9 @@ func (a *Store) AddEvidence(ctx context.Context, linkHash *types.Bytes32, eviden
 }
 
 // GetEvidences implements github.com/stratumn/go-indigocore/store.EvidenceReader.GetEvidences.
-func (a *Store) GetEvidences(ctx context.Context, linkHash *types.Bytes32) (*cs.Evidences, error) {
+func (a *Store) GetEvidences(ctx context.Context, linkHash *types.Bytes32) (_ *cs.Evidences, err error) {
 	ctx, span := trace.StartSpan(ctx, "rethinkstore/GetEvidences")
-	defer span.End()
+	defer monitoring.SetSpanStatusAndEnd(span, err)
 
 	cur, err := a.evidences.Get(linkHash).Run(a.session)
 	if err != nil {
@@ -469,9 +470,9 @@ func (a *Store) GetEvidences(ctx context.Context, linkHash *types.Bytes32) (*cs.
 }
 
 // GetValue implements github.com/stratumn/go-indigocore/store.KeyValueStore.GetValue.
-func (a *Store) GetValue(ctx context.Context, key []byte) ([]byte, error) {
+func (a *Store) GetValue(ctx context.Context, key []byte) (_ []byte, err error) {
 	ctx, span := trace.StartSpan(ctx, "rethinkstore/GetValue")
-	defer span.End()
+	defer monitoring.SetSpanStatusAndEnd(span, err)
 
 	cur, err := a.values.Get(key).Run(a.session)
 	if err != nil {
@@ -491,9 +492,9 @@ func (a *Store) GetValue(ctx context.Context, key []byte) ([]byte, error) {
 }
 
 // SetValue implements github.com/stratumn/go-indigocore/store.KeyValueStore.SetValue.
-func (a *Store) SetValue(ctx context.Context, key, value []byte) error {
+func (a *Store) SetValue(ctx context.Context, key, value []byte) (err error) {
 	ctx, span := trace.StartSpan(ctx, "rethinkstore/SetValue")
-	defer span.End()
+	defer monitoring.SetSpanStatusAndEnd(span, err)
 
 	v := &valueWrapper{
 		ID:    key,
@@ -504,9 +505,9 @@ func (a *Store) SetValue(ctx context.Context, key, value []byte) error {
 }
 
 // DeleteValue implements github.com/stratumn/go-indigocore/store.KeyValueStore.DeleteValue.
-func (a *Store) DeleteValue(ctx context.Context, key []byte) ([]byte, error) {
+func (a *Store) DeleteValue(ctx context.Context, key []byte) (_ []byte, err error) {
 	ctx, span := trace.StartSpan(ctx, "rethinkstore/DeleteValue")
-	defer span.End()
+	defer monitoring.SetSpanStatusAndEnd(span, err)
 
 	res, err := a.values.
 		Get(key).
@@ -536,9 +537,9 @@ type rethinkBufferedBatch struct {
 }
 
 // CreateLink implements github.com/stratumn/go-indigocore/store.LinkWriter.CreateLink.
-func (b *rethinkBufferedBatch) CreateLink(ctx context.Context, link *cs.Link) (*types.Bytes32, error) {
+func (b *rethinkBufferedBatch) CreateLink(ctx context.Context, link *cs.Link) (_ *types.Bytes32, err error) {
 	ctx, span := trace.StartSpan(ctx, "rethinkstore/CreateLink")
-	defer span.End()
+	defer monitoring.SetSpanStatusAndEnd(span, err)
 
 	formatLink(link)
 	return b.Batch.CreateLink(ctx, link)

--- a/tmpop/state.go
+++ b/tmpop/state.go
@@ -53,7 +53,7 @@ func NewState(ctx context.Context, a store.Adapter, config *Config) (*State, err
 
 	// With transactional databases we cannot really use two transactions as they'd lock each other
 	// (more exactly, checked links would lock out delivered links)
-	checkedLinks := bufferedbatch.NewBatch(a)
+	checkedLinks := bufferedbatch.NewBatch(ctx, a)
 
 	state := &State{
 		adapter:        a,
@@ -135,7 +135,7 @@ func (s *State) Commit(ctx context.Context) (*types.Bytes32, []*cs.Link, error) 
 	if s.deliveredLinks, err = s.adapter.NewBatch(ctx); err != nil {
 		return nil, nil, err
 	}
-	s.checkedLinks = bufferedbatch.NewBatch(s.adapter)
+	s.checkedLinks = bufferedbatch.NewBatch(ctx, s.adapter)
 
 	committedLinks := make([]*cs.Link, len(s.deliveredLinksList))
 	copy(committedLinks, s.deliveredLinksList)

--- a/tmpop/tmpop.go
+++ b/tmpop/tmpop.go
@@ -208,6 +208,7 @@ func (t *TMPop) DeliverTx(tx []byte) abci.ResponseDeliverTx {
 	if !err.IsOK() {
 		ctx, _ = tag.New(ctx, tag.Upsert(txStatus, "invalid"))
 		stats.Record(ctx, txCount.M(1))
+		span.SetStatus(trace.Status{Code: monitoring.InvalidArgument, Message: err.Log})
 		return abci.ResponseDeliverTx{
 			Code: err.Code,
 			Log:  err.Log,
@@ -226,6 +227,7 @@ func (t *TMPop) CheckTx(tx []byte) abci.ResponseCheckTx {
 
 	err := t.doTx(ctx, t.state.Check, tx)
 	if !err.IsOK() {
+		span.SetStatus(trace.Status{Code: monitoring.InvalidArgument, Message: err.Log})
 		return abci.ResponseCheckTx{
 			Code: err.Code,
 			Log:  err.Log,


### PR DESCRIPTION
Add basic tracing of the top-level methods for all stores.
Add error tagging.
Add a few metrics on bufferedbatch.
I don't know yet what metrics would make sense for each of the specific stores, I think that's something we'll add afterwards when we know what we want to monitor (SQL query time, number of rows impacted, etc).
I created issue #374 which would help our monitoring give us more insight (and the ability to alert on specific errors).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/go-indigocore/375)
<!-- Reviewable:end -->
