### PR TITLE
monitoring: instrument fossilizers

### DIFF
--- a/batchfossilizer/batchfossilizer.go
+++ b/batchfossilizer/batchfossilizer.go
@@ -376,6 +376,7 @@ func (a *Fossilizer) batch(b *batch) {
 						"file":  filepath.Base(path),
 						"error": err,
 					}).Warn("Failed to remove batch file")
+					span.Annotatef(nil, "Failed to remove batch file: %s", err.Error())
 				}
 			}
 		}

--- a/batchfossilizer/batchfossilizer.go
+++ b/batchfossilizer/batchfossilizer.go
@@ -195,9 +195,6 @@ func New(config *Config) (*Fossilizer, error) {
 
 // GetInfo implements github.com/stratumn/go-indigocore/fossilizer.Adapter.GetInfo.
 func (a *Fossilizer) GetInfo(ctx context.Context) (interface{}, error) {
-	ctx, span := trace.StartSpan(ctx, "batchfossilizer/GetInfo")
-	defer span.End()
-
 	return &Info{
 		Name:        Name,
 		Description: Description,
@@ -215,15 +212,11 @@ func (a *Fossilizer) AddFossilizerEventChan(fossilizerEventChan chan *fossilizer
 }
 
 // Fossilize implements github.com/stratumn/go-indigocore/fossilizer.Adapter.Fossilize.
-func (a *Fossilizer) Fossilize(ctx context.Context, data []byte, meta []byte) (err error) {
-	ctx, span := trace.StartSpan(ctx, "batchfossilizer/Fossilize")
-	defer monitoring.SetSpanStatusAndEnd(span, err)
-
+func (a *Fossilizer) Fossilize(ctx context.Context, data []byte, meta []byte) error {
 	f := fossil{Meta: meta}
 	f.Data = data
 	a.fossilChan <- &f
-	err = <-a.resultChan
-	return
+	return <-a.resultChan
 }
 
 // Start starts the fossilizer.

--- a/batchfossilizer/batchfossilizer_test.go
+++ b/batchfossilizer/batchfossilizer_test.go
@@ -36,7 +36,7 @@ func TestGetInfo(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New(): err: %s", err)
 	}
-	got, err := a.GetInfo()
+	got, err := a.GetInfo(context.Background())
 	if err != nil {
 		t.Fatalf("a.GetInfo(): err: %s", err)
 	}
@@ -101,6 +101,8 @@ func TestFossilize_Interval(t *testing.T) {
 }
 
 func TestStop_StopBatch(t *testing.T) {
+	ctx := context.Background()
+
 	t.Parallel()
 	path, err := ioutil.TempDir("", "batchfossilizer")
 	if err != nil {
@@ -120,19 +122,19 @@ func TestStop_StopBatch(t *testing.T) {
 		}
 	}()
 
-	if err := a.Fossilize(atos(sha256.Sum256([]byte("a"))), []byte("test a")); err != nil {
+	if err := a.Fossilize(ctx, atos(sha256.Sum256([]byte("a"))), []byte("test a")); err != nil {
 		t.Errorf("a.Fossilize(): err: %s", err)
 	}
-	if err := a.Fossilize(atos(sha256.Sum256([]byte("b"))), []byte("test b")); err != nil {
+	if err := a.Fossilize(ctx, atos(sha256.Sum256([]byte("b"))), []byte("test b")); err != nil {
 		t.Errorf("a.Fossilize(): err: %s", err)
 	}
-	if err := a.Fossilize(atos(sha256.Sum256([]byte("c"))), []byte("test c")); err != nil {
+	if err := a.Fossilize(ctx, atos(sha256.Sum256([]byte("c"))), []byte("test c")); err != nil {
 		t.Errorf("a.Fossilize(): err: %s", err)
 	}
-	if err := a.Fossilize(atos(sha256.Sum256([]byte("d"))), []byte("test d")); err != nil {
+	if err := a.Fossilize(ctx, atos(sha256.Sum256([]byte("d"))), []byte("test d")); err != nil {
 		t.Errorf("a.Fossilize(): err: %s", err)
 	}
-	if err := a.Fossilize(atos(sha256.Sum256([]byte("e"))), []byte("test e")); err != nil {
+	if err := a.Fossilize(ctx, atos(sha256.Sum256([]byte("e"))), []byte("test e")); err != nil {
 		t.Errorf("a.Fossilize(): err: %s", err)
 	}
 
@@ -178,6 +180,8 @@ func TestFossilize_Archive(t *testing.T) {
 }
 
 func TestNew_recover(t *testing.T) {
+	ctx := context.Background()
+
 	t.Parallel()
 	path, err := ioutil.TempDir("", "batchfossilizer")
 	if err != nil {
@@ -198,19 +202,19 @@ func TestNew_recover(t *testing.T) {
 		}
 	}()
 
-	if err := a.Fossilize(atos(sha256.Sum256([]byte("a"))), []byte("test a")); err != nil {
+	if err := a.Fossilize(ctx, atos(sha256.Sum256([]byte("a"))), []byte("test a")); err != nil {
 		t.Errorf("a.Fossilize(): err: %s", err)
 	}
-	if err := a.Fossilize(atos(sha256.Sum256([]byte("b"))), []byte("test b")); err != nil {
+	if err := a.Fossilize(ctx, atos(sha256.Sum256([]byte("b"))), []byte("test b")); err != nil {
 		t.Errorf("a.Fossilize(): err: %s", err)
 	}
-	if err := a.Fossilize(atos(sha256.Sum256([]byte("c"))), []byte("test c")); err != nil {
+	if err := a.Fossilize(ctx, atos(sha256.Sum256([]byte("c"))), []byte("test c")); err != nil {
 		t.Errorf("a.Fossilize(): err: %s", err)
 	}
-	if err := a.Fossilize(atos(sha256.Sum256([]byte("d"))), []byte("test d")); err != nil {
+	if err := a.Fossilize(ctx, atos(sha256.Sum256([]byte("d"))), []byte("test d")); err != nil {
 		t.Errorf("a.Fossilize(): err: %s", err)
 	}
-	if err := a.Fossilize(atos(sha256.Sum256([]byte("e"))), []byte("test e")); err != nil {
+	if err := a.Fossilize(ctx, atos(sha256.Sum256([]byte("e"))), []byte("test e")); err != nil {
 		t.Errorf("a.Fossilize(): err: %s", err)
 	}
 

--- a/batchfossilizer/metrics.go
+++ b/batchfossilizer/metrics.go
@@ -1,0 +1,62 @@
+// Copyright 2017 Stratumn SAS. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package batchfossilizer
+
+import (
+	"log"
+
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+)
+
+var (
+	batchCount           *stats.Int64Measure
+	fossilizedLinksCount *stats.Int64Measure
+)
+
+func init() {
+	var err error
+	if batchCount, err = stats.Int64(
+		"stratumn/indigocore/batchfossilizer/batch_count",
+		"number of batches sent",
+		stats.UnitNone,
+	); err != nil {
+		log.Fatal(err)
+	}
+
+	if fossilizedLinksCount, err = stats.Int64(
+		"stratumn/indigocore/batchfossilizer/fossilized_links_count",
+		"number of links fossilized",
+		stats.UnitNone,
+	); err != nil {
+		log.Fatal(err)
+	}
+
+	if err = view.Subscribe(
+		&view.View{
+			Name:        "batch_count",
+			Description: "number of batches sent",
+			Measure:     batchCount,
+			Aggregation: view.Count(),
+		},
+		&view.View{
+			Name:        "fossilized_links_count",
+			Description: "number of links fossilized",
+			Measure:     fossilizedLinksCount,
+			Aggregation: view.Count(),
+		}); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/batchfossilizer/util_test.go
+++ b/batchfossilizer/util_test.go
@@ -41,6 +41,8 @@ type fossilizeTest struct {
 }
 
 func testFossilizeMultiple(t *testing.T, a *Fossilizer, tests []fossilizeTest, start bool, fossilize bool) (results []*fossilizer.Result) {
+	ctx := context.Background()
+
 	ec := make(chan *fossilizer.Event, 1)
 	a.AddFossilizerEventChan(ec)
 	var cancel context.CancelFunc
@@ -62,7 +64,7 @@ func testFossilizeMultiple(t *testing.T, a *Fossilizer, tests []fossilizeTest, s
 
 	if fossilize {
 		for _, test := range tests {
-			if err := a.Fossilize(test.data, test.meta); err != nil {
+			if err := a.Fossilize(ctx, test.data, test.meta); err != nil {
 				t.Errorf("a.Fossilize(): err: %s", err)
 			}
 			if test.sleep > 0 {
@@ -141,7 +143,7 @@ func benchmarkFossilize(b *testing.B, config *Config) {
 
 	go func() {
 		for i := 0; i < n; i++ {
-			if err := a.Fossilize(data[i], data[i]); err != nil {
+			if err := a.Fossilize(context.Background(), data[i], data[i]); err != nil {
 				b.Errorf("a.Fossilize(): err: %s", err)
 			}
 		}

--- a/bcbatchfossilizer/bcbatchfossilizer.go
+++ b/bcbatchfossilizer/bcbatchfossilizer.go
@@ -17,17 +17,19 @@
 package bcbatchfossilizer
 
 import (
+	"context"
 	"fmt"
 
 	log "github.com/sirupsen/logrus"
-
+	"github.com/stratumn/go-indigocore/batchfossilizer"
+	"github.com/stratumn/go-indigocore/blockchain"
 	"github.com/stratumn/go-indigocore/cs"
 	"github.com/stratumn/go-indigocore/cs/evidences"
 	"github.com/stratumn/go-indigocore/fossilizer"
+	"github.com/stratumn/go-indigocore/monitoring"
 	"github.com/stratumn/go-indigocore/types"
 
-	"github.com/stratumn/go-indigocore/batchfossilizer"
-	"github.com/stratumn/go-indigocore/blockchain"
+	"go.opencensus.io/trace"
 )
 
 const (
@@ -83,8 +85,11 @@ func New(config *Config, batchConfig *batchfossilizer.Config) (*Fossilizer, erro
 }
 
 // GetInfo implements github.com/stratumn/go-indigocore/fossilizer.Adapter.GetInfo.
-func (a *Fossilizer) GetInfo() (interface{}, error) {
-	batchInfo, err := a.Fossilizer.GetInfo()
+func (a *Fossilizer) GetInfo(ctx context.Context) (_ interface{}, err error) {
+	ctx, span := trace.StartSpan(ctx, "bcbatchfossilizer/GetInfo")
+	defer monitoring.SetSpanStatusAndEnd(span, err)
+
+	batchInfo, err := a.Fossilizer.GetInfo(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/bcbatchfossilizer/bcbatchfossilizer.go
+++ b/bcbatchfossilizer/bcbatchfossilizer.go
@@ -26,10 +26,7 @@ import (
 	"github.com/stratumn/go-indigocore/cs"
 	"github.com/stratumn/go-indigocore/cs/evidences"
 	"github.com/stratumn/go-indigocore/fossilizer"
-	"github.com/stratumn/go-indigocore/monitoring"
 	"github.com/stratumn/go-indigocore/types"
-
-	"go.opencensus.io/trace"
 )
 
 const (
@@ -85,10 +82,7 @@ func New(config *Config, batchConfig *batchfossilizer.Config) (*Fossilizer, erro
 }
 
 // GetInfo implements github.com/stratumn/go-indigocore/fossilizer.Adapter.GetInfo.
-func (a *Fossilizer) GetInfo(ctx context.Context) (_ interface{}, err error) {
-	ctx, span := trace.StartSpan(ctx, "bcbatchfossilizer/GetInfo")
-	defer monitoring.SetSpanStatusAndEnd(span, err)
-
+func (a *Fossilizer) GetInfo(ctx context.Context) (interface{}, error) {
 	batchInfo, err := a.Fossilizer.GetInfo(ctx)
 	if err != nil {
 		return nil, err

--- a/bcbatchfossilizer/bcbatchfossilizer_test.go
+++ b/bcbatchfossilizer/bcbatchfossilizer_test.go
@@ -15,6 +15,7 @@
 package bcbatchfossilizer
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/json"
 	"testing"
@@ -32,7 +33,7 @@ func TestGetInfo(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New(): err: %s", err)
 	}
-	got, err := a.GetInfo()
+	got, err := a.GetInfo(context.Background())
 	if err != nil {
 		t.Fatalf("a.GetInfo(): err: %s", err)
 	}

--- a/bcbatchfossilizer/util_test.go
+++ b/bcbatchfossilizer/util_test.go
@@ -56,7 +56,7 @@ func testFossilizeMultiple(t *testing.T, a *Fossilizer, tests []fossilizeTest) (
 	<-a.Started()
 
 	for _, test := range tests {
-		if err := a.Fossilize(test.data, test.meta); err != nil {
+		if err := a.Fossilize(context.Background(), test.data, test.meta); err != nil {
 			t.Errorf("a.Fossilize(): err: %s", err)
 		}
 		if test.sleep > 0 {
@@ -131,7 +131,7 @@ func benchmarkFossilize(b *testing.B, config *Config, batchConfig *batchfossiliz
 
 	go func() {
 		for i := 0; i < n; i++ {
-			if err := a.Fossilize(data[i], data[i]); err != nil {
+			if err := a.Fossilize(context.Background(), data[i], data[i]); err != nil {
 				b.Errorf("a.Fossilize(): err: %s", err)
 			}
 		}

--- a/cmd/btcfossilizer/main.go
+++ b/cmd/btcfossilizer/main.go
@@ -20,6 +20,7 @@ import (
 	"os"
 
 	"github.com/stratumn/go-indigocore/fossilizer/fossilizerhttp"
+	"github.com/stratumn/go-indigocore/monitoring"
 	"github.com/stratumn/go-indigocore/utils"
 
 	"github.com/stratumn/go-indigocore/bcbatchfossilizer"
@@ -39,6 +40,7 @@ func init() {
 	blockcypher.RegisterFlags()
 	btctimestamper.RegisterFlags()
 	bcbatchfossilizer.RegisterFlags()
+	monitoring.RegisterFlags()
 }
 
 func main() {

--- a/cmd/btcfossilizer/main.go
+++ b/cmd/btcfossilizer/main.go
@@ -51,6 +51,9 @@ func main() {
 
 	bcy := blockcypher.RunWithFlags(ctx, *key)
 	ts := btctimestamper.InitializeWithFlags(version, commit, *key, bcy, bcy)
-	a := bcbatchfossilizer.RunWithFlags(ctx, version, commit, ts)
+	a := monitoring.NewFossilizerAdapter(
+		bcbatchfossilizer.RunWithFlags(ctx, version, commit, ts),
+		"bcbatchfossilizer",
+	)
 	fossilizerhttp.RunWithFlags(ctx, a)
 }

--- a/cmd/dummybatchfossilizer/main.go
+++ b/cmd/dummybatchfossilizer/main.go
@@ -43,6 +43,9 @@ func main() {
 	ctx := context.Background()
 	ctx = utils.CancelOnInterrupt(ctx)
 
-	a := bcbatchfossilizer.RunWithFlags(ctx, version, commit, dummytimestamper.Timestamper{})
+	a := monitoring.NewFossilizerAdapter(
+		bcbatchfossilizer.RunWithFlags(ctx, version, commit, dummytimestamper.Timestamper{}),
+		"dummybatchfossilizer",
+	)
 	fossilizerhttp.RunWithFlags(ctx, a)
 }

--- a/cmd/dummyfossilizer/main.go
+++ b/cmd/dummyfossilizer/main.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/stratumn/go-indigocore/dummyfossilizer"
 	"github.com/stratumn/go-indigocore/fossilizer/fossilizerhttp"
+	"github.com/stratumn/go-indigocore/monitoring"
 	"github.com/stratumn/go-indigocore/utils"
 )
 
@@ -34,6 +35,7 @@ var (
 
 func init() {
 	fossilizerhttp.RegisterFlags()
+	monitoring.RegisterFlags()
 }
 
 func main() {

--- a/cmd/dummyfossilizer/main.go
+++ b/cmd/dummyfossilizer/main.go
@@ -45,6 +45,9 @@ func main() {
 	ctx = utils.CancelOnInterrupt(ctx)
 
 	log.Infof("%s v%s@%s", dummyfossilizer.Description, version, commit[:7])
-	a := dummyfossilizer.New(&dummyfossilizer.Config{Version: version, Commit: commit})
+	a := monitoring.NewFossilizerAdapter(
+		dummyfossilizer.New(&dummyfossilizer.Config{Version: version, Commit: commit}),
+		"dummyfossilizer",
+	)
 	fossilizerhttp.RunWithFlags(ctx, a)
 }

--- a/dummyfossilizer/dummyfossilizer.go
+++ b/dummyfossilizer/dummyfossilizer.go
@@ -24,8 +24,6 @@ import (
 
 	"github.com/stratumn/go-indigocore/cs"
 	"github.com/stratumn/go-indigocore/fossilizer"
-
-	"go.opencensus.io/trace"
 )
 
 const (
@@ -102,9 +100,6 @@ func New(config *Config) *DummyFossilizer {
 
 // GetInfo implements github.com/stratumn/go-indigocore/fossilizer.Adapter.GetInfo.
 func (a *DummyFossilizer) GetInfo(ctx context.Context) (interface{}, error) {
-	ctx, span := trace.StartSpan(ctx, "dummyfossilizer/GetInfo")
-	defer span.End()
-
 	return &Info{
 		Name:        Name,
 		Description: Description,
@@ -121,9 +116,6 @@ func (a *DummyFossilizer) AddFossilizerEventChan(fossilizerEventChan chan *fossi
 
 // Fossilize implements github.com/stratumn/go-indigocore/fossilizer.Adapter.Fossilize.
 func (a *DummyFossilizer) Fossilize(ctx context.Context, data []byte, meta []byte) error {
-	ctx, span := trace.StartSpan(ctx, "dummyfossilizer/Fossilize")
-	defer span.End()
-
 	r := &fossilizer.Result{
 		Evidence: cs.Evidence{
 			Backend:  Name,

--- a/dummyfossilizer/dummyfossilizer.go
+++ b/dummyfossilizer/dummyfossilizer.go
@@ -18,11 +18,14 @@
 package dummyfossilizer
 
 import (
+	"context"
 	"encoding/json"
 	"time"
 
 	"github.com/stratumn/go-indigocore/cs"
 	"github.com/stratumn/go-indigocore/fossilizer"
+
+	"go.opencensus.io/trace"
 )
 
 const (
@@ -98,7 +101,10 @@ func New(config *Config) *DummyFossilizer {
 }
 
 // GetInfo implements github.com/stratumn/go-indigocore/fossilizer.Adapter.GetInfo.
-func (a *DummyFossilizer) GetInfo() (interface{}, error) {
+func (a *DummyFossilizer) GetInfo(ctx context.Context) (interface{}, error) {
+	ctx, span := trace.StartSpan(ctx, "dummyfossilizer/GetInfo")
+	defer span.End()
+
 	return &Info{
 		Name:        Name,
 		Description: Description,
@@ -114,7 +120,9 @@ func (a *DummyFossilizer) AddFossilizerEventChan(fossilizerEventChan chan *fossi
 }
 
 // Fossilize implements github.com/stratumn/go-indigocore/fossilizer.Adapter.Fossilize.
-func (a *DummyFossilizer) Fossilize(data []byte, meta []byte) error {
+func (a *DummyFossilizer) Fossilize(ctx context.Context, data []byte, meta []byte) error {
+	ctx, span := trace.StartSpan(ctx, "dummyfossilizer/Fossilize")
+	defer span.End()
 
 	r := &fossilizer.Result{
 		Evidence: cs.Evidence{

--- a/dummyfossilizer/dummyfossilizer_test.go
+++ b/dummyfossilizer/dummyfossilizer_test.go
@@ -16,6 +16,7 @@ package dummyfossilizer
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -25,7 +26,7 @@ import (
 
 func TestGetInfo(t *testing.T) {
 	a := New(&Config{})
-	got, err := a.GetInfo()
+	got, err := a.GetInfo(context.Background())
 	if err != nil {
 		t.Fatalf("a.GetInfo(): err: %s", err)
 	}
@@ -45,7 +46,7 @@ func TestFossilize(t *testing.T) {
 	)
 
 	go func() {
-		if err := a.Fossilize(data, meta); err != nil {
+		if err := a.Fossilize(context.Background(), data, meta); err != nil {
 			t.Errorf("a.Fossilize(): err: %s", err)
 		}
 	}()
@@ -76,7 +77,7 @@ func TestDummyProof(t *testing.T) {
 	)
 
 	go func() {
-		if err := a.Fossilize(data, meta); err != nil {
+		if err := a.Fossilize(context.Background(), data, meta); err != nil {
 			t.Errorf("a.Fossilize(): err: %s", err)
 		}
 	}()

--- a/fossilizer/fossilizer.go
+++ b/fossilizer/fossilizer.go
@@ -16,20 +16,22 @@
 package fossilizer
 
 import (
+	"context"
+
 	"github.com/stratumn/go-indigocore/cs"
 )
 
 // Adapter must be implemented by a fossilier.
 type Adapter interface {
 	// Returns arbitrary information about the adapter.
-	GetInfo() (interface{}, error)
+	GetInfo(context.Context) (interface{}, error)
 
 	// Adds a channel that receives events from the fossilizer
 	AddFossilizerEventChan(chan *Event)
 
 	// Requests data to be fossilized.
 	// Meta is arbitrary data that will be forwarded to the websocket.
-	Fossilize(data []byte, meta []byte) error
+	Fossilize(ctx context.Context, data []byte, meta []byte) error
 }
 
 // Result is the type sent to the result channels.

--- a/fossilizer/fossilizerhttp/cmd.go
+++ b/fossilizer/fossilizerhttp/cmd.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stratumn/go-indigocore/fossilizer"
 	"github.com/stratumn/go-indigocore/jsonhttp"
 	"github.com/stratumn/go-indigocore/jsonws"
+	"github.com/stratumn/go-indigocore/monitoring"
 )
 
 var (
@@ -53,6 +54,7 @@ func Run(
 	ctx context.Context,
 	a fossilizer.Adapter,
 	config *Config,
+	monitoringConfig *monitoring.Config,
 	httpConfig *jsonhttp.Config,
 	basicConfig *jsonws.BasicConfig,
 	bufConnConfig *jsonws.BufferedConnConfig,
@@ -63,6 +65,7 @@ func Run(
 	log.Infof("Runtime %s %s %s", runtime.Version(), runtime.GOOS, runtime.GOARCH)
 
 	h := New(a, config, httpConfig, basicConfig, bufConnConfig)
+	h.exposeMetrics(monitoringConfig)
 
 	go func() {
 		<-ctx.Done()
@@ -108,6 +111,7 @@ func RunWithFlags(ctx context.Context, a fossilizer.Adapter) {
 		MaxDataLen:              maxDataLen,
 		FossilizerEventChanSize: fossilizerEventChanSize,
 	}
+	monitoringConfig := monitoring.ConfigurationFromFlags()
 	httpConfig := &jsonhttp.Config{
 		Address:        addr,
 		ReadTimeout:    readTimeout,
@@ -132,6 +136,7 @@ func RunWithFlags(ctx context.Context, a fossilizer.Adapter) {
 		ctx,
 		a,
 		config,
+		monitoringConfig,
 		httpConfig,
 		basicConfig,
 		bufConnConfig,

--- a/fossilizer/fossilizertesting/example_test.go
+++ b/fossilizer/fossilizertesting/example_test.go
@@ -15,6 +15,7 @@
 package fossilizertesting_test
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -34,7 +35,7 @@ func ExampleMockAdapter() {
 	}
 
 	// Execute GetInfo on the mock.
-	i, err := m.GetInfo()
+	i, err := m.GetInfo(context.Background())
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/fossilizer/fossilizertesting/mockadapter.go
+++ b/fossilizer/fossilizertesting/mockadapter.go
@@ -15,6 +15,8 @@
 package fossilizertesting
 
 import (
+	"context"
+
 	"github.com/stratumn/go-indigocore/fossilizer"
 )
 
@@ -78,7 +80,7 @@ type MockFossilize struct {
 }
 
 // GetInfo implements github.com/stratumn/go-indigocore/fossilizer.Adapter.GetInfo.
-func (a *MockAdapter) GetInfo() (interface{}, error) {
+func (a *MockAdapter) GetInfo(_ context.Context) (interface{}, error) {
 	a.MockGetInfo.CalledCount++
 
 	if a.MockGetInfo.Fn != nil {
@@ -101,7 +103,7 @@ func (a *MockAdapter) AddFossilizerEventChan(eventChan chan *fossilizer.Event) {
 }
 
 // Fossilize implements github.com/stratumn/go-indigocore/fossilizer.Adapter.Fossilize.
-func (a *MockAdapter) Fossilize(data []byte, meta []byte) error {
+func (a *MockAdapter) Fossilize(_ context.Context, data []byte, meta []byte) error {
 	a.MockFossilize.CalledCount++
 	a.MockFossilize.CalledWithData = append(a.MockFossilize.CalledWithData, data)
 	a.MockFossilize.LastCalledWithData = data

--- a/fossilizer/fossilizertesting/mockadapter_test.go
+++ b/fossilizer/fossilizertesting/mockadapter_test.go
@@ -15,6 +15,7 @@
 package fossilizertesting
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -24,12 +25,12 @@ import (
 func TestMockAdapter_GetInfo(t *testing.T) {
 	a := &MockAdapter{}
 
-	if _, err := a.GetInfo(); err != nil {
+	if _, err := a.GetInfo(context.Background()); err != nil {
 		t.Fatalf("a.GetInfo(): err: %s", err)
 	}
 
 	a.MockGetInfo.Fn = func() (interface{}, error) { return map[string]string{"name": "test"}, nil }
-	info, err := a.GetInfo()
+	info, err := a.GetInfo(context.Background())
 	if err != nil {
 		t.Fatalf("a.GetInfo(): err: %s", err)
 	}
@@ -74,7 +75,7 @@ func TestMockAdapter_Fossilize(t *testing.T) {
 	d1 := []byte("data1")
 	m1 := []byte("meta1")
 
-	if err := a.Fossilize(d1, m1); err != nil {
+	if err := a.Fossilize(context.Background(), d1, m1); err != nil {
 		t.Fatalf("a.Fossilize(): err: %s", err)
 	}
 
@@ -83,7 +84,7 @@ func TestMockAdapter_Fossilize(t *testing.T) {
 	d2 := []byte("data2")
 	m2 := []byte("meta2")
 
-	if err := a.Fossilize(d2, m2); err != nil {
+	if err := a.Fossilize(context.Background(), d2, m2); err != nil {
 		t.Errorf("a.Fossilize(): err: %s", err)
 	}
 

--- a/monitoring/fossilizer.go
+++ b/monitoring/fossilizer.go
@@ -1,0 +1,62 @@
+// Copyright 2017 Stratumn SAS. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package monitoring
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/stratumn/go-indigocore/fossilizer"
+
+	"go.opencensus.io/trace"
+)
+
+// FossilizerAdapter is a decorator for the Fossilizer interface.
+// It wraps a real Fossilizer implementation and adds instrumentation.
+type FossilizerAdapter struct {
+	f    fossilizer.Adapter
+	name string
+}
+
+// NewFossilizerAdapter decorates an existing fossilizer.
+func NewFossilizerAdapter(f fossilizer.Adapter, name string) fossilizer.Adapter {
+	return &FossilizerAdapter{f: f, name: name}
+}
+
+// GetInfo instruments the call and delegates to the underlying fossilizer.
+func (a *FossilizerAdapter) GetInfo(ctx context.Context) (res interface{}, err error) {
+	ctx, span := trace.StartSpan(ctx, fmt.Sprintf("%s/GetInfo", a.name))
+	defer SetSpanStatusAndEnd(span, err)
+
+	res, err = a.f.GetInfo(ctx)
+	return
+}
+
+// AddFossilizerEventChan instruments the call and delegates to the underlying fossilizer.
+func (a *FossilizerAdapter) AddFossilizerEventChan(c chan *fossilizer.Event) {
+	_, span := trace.StartSpan(context.Background(), fmt.Sprintf("%s/AddFossilizerEventChan", a.name))
+	defer span.End()
+
+	a.AddFossilizerEventChan(c)
+}
+
+// Fossilize instruments the call and delegates to the underlying fossilizer.
+func (a *FossilizerAdapter) Fossilize(ctx context.Context, data []byte, meta []byte) (err error) {
+	ctx, span := trace.StartSpan(ctx, fmt.Sprintf("%s/Fossilize", a.name))
+	defer SetSpanStatusAndEnd(span, err)
+
+	err = a.f.Fossilize(ctx, data, meta)
+	return
+}


### PR DESCRIPTION
Add instrumentation to fossilizers.
Because of the async job design with channels, traces will be decorrelated, but that's still helpful.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/go-indigocore/378)
<!-- Reviewable:end -->
