### PR TITLE
monitoring: decorate tm underlying stores with monitoring

### DIFF
--- a/cmd/dummytmpop/main.go
+++ b/cmd/dummytmpop/main.go
@@ -46,5 +46,9 @@ func main() {
 		ValidatorFilename: *validatorFilename,
 		Monitoring:        monitoring.ConfigurationFromFlags(),
 	}
-	tmpop.Run(a, a, tmpopConfig)
+	tmpop.Run(
+		monitoring.NewStoreAdapter(a, "dummystore"),
+		monitoring.NewKeyValueStoreAdapter(a, "dummystore"),
+		tmpopConfig,
+	)
 }

--- a/cmd/filetmpop/main.go
+++ b/cmd/filetmpop/main.go
@@ -53,5 +53,9 @@ func main() {
 		ValidatorFilename: *validatorFilename,
 		Monitoring:        monitoring.ConfigurationFromFlags(),
 	}
-	tmpop.Run(a, a, tmpopConfig)
+	tmpop.Run(
+		monitoring.NewStoreAdapter(a, "filestore"),
+		monitoring.NewKeyValueStoreAdapter(a, "filestore"),
+		tmpopConfig,
+	)
 }

--- a/cmd/postgrestmpop/main.go
+++ b/cmd/postgrestmpop/main.go
@@ -47,5 +47,9 @@ func main() {
 		ValidatorFilename: *validatorFilename,
 		Monitoring:        monitoring.ConfigurationFromFlags(),
 	}
-	tmpop.Run(a, a, tmpopConfig)
+	tmpop.Run(
+		monitoring.NewStoreAdapter(a, "postgresstore"),
+		monitoring.NewKeyValueStoreAdapter(a, "postgresstore"),
+		tmpopConfig,
+	)
 }

--- a/cmd/rethinktmpop/main.go
+++ b/cmd/rethinktmpop/main.go
@@ -47,5 +47,9 @@ func main() {
 		ValidatorFilename: *validatorFilename,
 		Monitoring:        monitoring.ConfigurationFromFlags(),
 	}
-	tmpop.Run(a, a, tmpopConfig)
+	tmpop.Run(
+		monitoring.NewStoreAdapter(a, "rethinkstore"),
+		monitoring.NewKeyValueStoreAdapter(a, "rethinkstore"),
+		tmpopConfig,
+	)
 }

--- a/filestore/filestore.go
+++ b/filestore/filestore.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/stratumn/go-indigocore/cs"
 	"github.com/stratumn/go-indigocore/leveldbstore"
+	"github.com/stratumn/go-indigocore/monitoring"
 	"github.com/stratumn/go-indigocore/store"
 	"github.com/stratumn/go-indigocore/types"
 )
@@ -55,7 +56,7 @@ type FileStore struct {
 	config     *Config
 	eventChans []chan *store.Event
 	mutex      sync.RWMutex // simple global mutex
-	kvDB       *leveldbstore.LevelDBStore
+	kvDB       store.KeyValueStore
 }
 
 // Config contains configuration options for the store.
@@ -88,7 +89,12 @@ func New(config *Config) (*FileStore, error) {
 		return nil, err
 	}
 
-	return &FileStore{config, nil, sync.RWMutex{}, db}, nil
+	return &FileStore{
+		config,
+		nil,
+		sync.RWMutex{},
+		monitoring.NewKeyValueStoreAdapter(db, "leveldbstore"),
+	}, nil
 }
 
 /********** Store adapter implementation **********/


### PR DESCRIPTION
I thought about it and forgot to include it in the previous PR.
We want stores used internally by other stores to be wrapped in the monitoring decorator as well.