### PR TITLE
Generate keys from the CLI

### DIFF
--- a/generator/input.go
+++ b/generator/input.go
@@ -233,6 +233,60 @@ func (in *StringSelect) Run() (interface{}, error) {
 	return in.Options.FindValue(txt), err
 }
 
+// GenericSelectOptions is a map of options that can have any type
+type GenericSelectOptions map[interface{}]string
+
+// FindText have to be replaced when []StringSelectOption will be a map[string]string
+func (options GenericSelectOptions) FindText(value string) string {
+	if ret, ok := options[value]; ok {
+		return ret
+	}
+	return value
+}
+
+// FindValue have to be replaced when []StringSelectOption will be a map[string]string
+func (options GenericSelectOptions) FindValue(text string) interface{} {
+	for k, v := range options {
+		if text == v {
+			return k
+		}
+	}
+	return text
+}
+
+// GenericSelect contains properties for generic select input.
+type GenericSelect struct {
+	InputShared
+
+	// Default is the default value.
+	Default string `json:"default"`
+
+	// Options is a map of possible values.
+	Options GenericSelectOptions `json:"options"`
+}
+
+// Run implements github.com/stratumn/sdk/generator.Input.
+func (in *GenericSelect) Run() (interface{}, error) {
+	prompt := promptui.Select{
+		Label: in.Prompt,
+		Items: func() (items []interface{}) {
+			items = make([]interface{}, 0, len(in.Options))
+			if in.Default != "" {
+				items = append(items, in.Options.FindText(in.Default))
+			}
+			for k, v := range in.Options {
+				if in.Default == "" || k != in.Default {
+					items = append(items, v)
+				}
+			}
+			return
+		}(),
+		Size: len(in.Options),
+	}
+	_, txt, err := prompt.Run()
+	return in.Options.FindValue(txt), err
+}
+
 // StringSelectMulti contains properties for multiple select inputs.
 type StringSelectMulti struct {
 	InputShared

--- a/strat/cmd/key.go
+++ b/strat/cmd/key.go
@@ -1,0 +1,102 @@
+// Copyright 2017 Stratumn SAS. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"github.com/stratumn/go-crypto/keys"
+	"github.com/stratumn/go-indigocore/generator"
+)
+
+const (
+	keyExt       = ".pem"
+	pubKeySuffix = ".pub"
+)
+
+var (
+	keyFilename string
+)
+
+// keyCmd represents the info command
+var keyCmd = &cobra.Command{
+	Use:   "keygen",
+	Short: "Generate keys",
+	Long: `Generate key files.
+
+It currently supports 3 key algorithms : ED25519, RSA and ECDSA`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		in := generator.StringSelect{
+			InputShared: generator.InputShared{
+				Prompt: "What kind of key would you like to generate ?",
+			},
+			Options: generator.StringSelectOptions{},
+		}
+		keyOptions := map[x509.PublicKeyAlgorithm]string{
+			keys.ED25519: "ED25519",
+			x509.RSA:     "RSA",
+			x509.ECDSA:   "ECDSA",
+		}
+		for id, algoName := range keyOptions {
+			in.Options[strconv.Itoa(int(id))] = algoName
+		}
+		ret, err := in.Run()
+		if err != nil {
+			return err
+		}
+
+		algo, err := strconv.Atoi(ret.(string))
+		if err != nil {
+			return err
+		}
+
+		pub, priv, err := keys.GenerateKey(x509.PublicKeyAlgorithm(algo))
+		if err != nil {
+			return err
+		}
+
+		privKeyFilename := keyFilename + keyExt
+		err = ioutil.WriteFile(privKeyFilename, priv, 0666)
+		if err != nil {
+			return err
+		}
+
+		pubKeyFilename := keyFilename + pubKeySuffix + keyExt
+		err = ioutil.WriteFile(pubKeyFilename, pub, 0666)
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("Your secret key has been saved in %s.\nYour public key has been saved in %s\n", privKeyFilename, pubKeyFilename)
+		return nil
+	},
+}
+
+func init() {
+
+	RootCmd.AddCommand(keyCmd)
+	keyCmd.PersistentFlags().StringVarP(
+		&keyFilename,
+		"out",
+		"o",
+		"stratumn_key",
+		"Key filename",
+	)
+}

--- a/strat/cmd/key.go
+++ b/strat/cmd/key.go
@@ -18,7 +18,6 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io/ioutil"
-	"strconv"
 
 	"github.com/spf13/cobra"
 	"github.com/stratumn/go-crypto/keys"
@@ -43,31 +42,29 @@ var keyCmd = &cobra.Command{
 It currently supports 3 key algorithms : ED25519, RSA and ECDSA`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		in := generator.StringSelect{
+		in := generator.GenericSelect{
 			InputShared: generator.InputShared{
-				Prompt: "What kind of key would you like to generate ?",
+				Prompt: "Which type of key would you like to generate ?",
 			},
-			Options: generator.StringSelectOptions{},
+			Options: generator.GenericSelectOptions{},
 		}
 		keyOptions := map[x509.PublicKeyAlgorithm]string{
 			keys.ED25519: "ED25519",
 			x509.RSA:     "RSA",
 			x509.ECDSA:   "ECDSA",
 		}
-		for id, algoName := range keyOptions {
-			in.Options[strconv.Itoa(int(id))] = algoName
+
+		for name, id := range keyOptions {
+			in.Options[name] = id
 		}
 		ret, err := in.Run()
 		if err != nil {
 			return err
 		}
 
-		algo, err := strconv.Atoi(ret.(string))
-		if err != nil {
-			return err
-		}
+		algo := ret
 
-		pub, priv, err := keys.GenerateKey(x509.PublicKeyAlgorithm(algo))
+		pub, priv, err := keys.GenerateKey(algo.(x509.PublicKeyAlgorithm))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
I added an other kind of input instead of using `StringSelectOptions` biut I don't know if it's worth it...
I also tried modifying `StringSelectOptions` to a `map[interface{}]string` but it really was not convenient (good to know: `'{"some": "json"}'` cannot be unmarshalled into a go type `map[interface{}]string`)

I can still convert `x509.PublicKeyAlgorithm` to a `string` but meh...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/go-indigocore/381)
<!-- Reviewable:end -->
