### PR TITLE
cs: add missing mapID in cs.SegmentRef

### DIFF
--- a/agent/agenttestcases/createmap.go
+++ b/agent/agenttestcases/createmap.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	cj "github.com/gibson042/canonicaljson-go"
+	uuid "github.com/satori/go.uuid"
 	"github.com/stratumn/go-indigocore/cs"
 	"github.com/stratumn/go-indigocore/testutil"
 	"github.com/stretchr/testify/assert"
@@ -35,7 +36,7 @@ func (f Factory) TestCreateMapOK(t *testing.T) {
 // when one or multiple references are passed.
 func (f Factory) TestCreateMapWithRefs(t *testing.T) {
 	process := "test"
-	refs := []cs.SegmentReference{{Process: "other", LinkHash: testutil.RandomHash().String()}}
+	refs := []cs.SegmentReference{{Process: "other", MapID: uuid.NewV4().String(), LinkHash: testutil.RandomHash().String()}}
 
 	segment, err := f.Client.CreateMap(process, refs, "test")
 	assert.NoError(t, err)
@@ -54,7 +55,7 @@ func (f Factory) TestCreateMapWithBadRefs(t *testing.T) {
 
 	segment, err := f.Client.CreateMap(process, refs, arg)
 	assert.Error(t, err, "missing segment or (process and linkHash)")
-	assert.Contains(t, err.Error(), "linkHash should be a non empty string")
+	assert.EqualError(t, err, "cannot decode references: link.meta.refs[0].mapId should be a valid UUID V4")
 	assert.Nil(t, segment)
 }
 

--- a/agent/agenttestcases/createsegment.go
+++ b/agent/agenttestcases/createsegment.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	cj "github.com/gibson042/canonicaljson-go"
+	uuid "github.com/satori/go.uuid"
 
 	"github.com/stratumn/go-indigocore/cs"
 	"github.com/stratumn/go-indigocore/testutil"
@@ -41,7 +42,7 @@ func (f Factory) TestCreateSegmentOK(t *testing.T) {
 func (f Factory) TestCreateSegmentWithRefs(t *testing.T) {
 	process, action := "test", "test"
 	parent, _ := f.Client.CreateMap(process, nil, "test")
-	refs := []cs.SegmentReference{{Process: "other", LinkHash: testutil.RandomHash().String()}}
+	refs := []cs.SegmentReference{{Process: "other", MapID: uuid.NewV4().String(), LinkHash: testutil.RandomHash().String()}}
 
 	segment, err := f.Client.CreateSegment(process, parent.GetLinkHash(), action, refs, "one")
 	assert.NoError(t, err)
@@ -61,7 +62,7 @@ func (f Factory) TestCreateSegmentWithBadRefs(t *testing.T) {
 
 	segment, err := f.Client.CreateSegment(process, parent.GetLinkHash(), action, refs, arg)
 	assert.Error(t, err, "missing segment or (process and linkHash)")
-	assert.Contains(t, err.Error(), "linkHash should be a non empty string")
+	assert.EqualError(t, err, "cannot decode references: link.meta.refs[0].mapId should be a valid UUID V4")
 	assert.Nil(t, segment)
 }
 

--- a/cs/cs.go
+++ b/cs/cs.go
@@ -20,6 +20,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 
+	uuid "github.com/satori/go.uuid"
 	"github.com/stratumn/go-crypto/signatures"
 
 	"reflect"
@@ -130,6 +131,7 @@ func (s *SegmentMeta) FindEvidences(backend string) (res Evidences) {
 // SegmentReference is a reference to a segment or a linkHash
 type SegmentReference struct {
 	Segment  *Segment `json:"segment"`
+	MapID    string   `json:"mapId"`
 	Process  string   `json:"process"`
 	LinkHash string   `json:"linkHash"`
 }
@@ -231,6 +233,9 @@ func (l *Link) validateReferences(ctx context.Context, getSegment GetSegmentFunc
 		} else {
 			if ref.Process == "" {
 				return errors.Errorf("link.meta.refs[%d].process should be a non empty string", refIdx)
+			}
+			if mapID, err := uuid.FromString(ref.MapID); err != nil || mapID.Version() != uuid.V4 {
+				return errors.Errorf("link.meta.refs[%d].mapId should be a valid UUID V4", refIdx)
 			}
 			linkHash, err := types.NewBytes32FromString(ref.LinkHash)
 			if err != nil {

--- a/cs/cs_test.go
+++ b/cs/cs_test.go
@@ -21,6 +21,7 @@ import (
 	"sort"
 	"testing"
 
+	uuid "github.com/satori/go.uuid"
 	"github.com/stratumn/go-indigocore/cs"
 	"github.com/stratumn/go-indigocore/cs/cstesting"
 	"github.com/stratumn/go-indigocore/testutil"
@@ -141,32 +142,38 @@ func TestLinkValidate_refBadLink(t *testing.T) {
 
 func TestLinkValidate_refMissingProcess(t *testing.T) {
 	l := cstesting.RandomLink()
-	appendRefLink(l, "", testutil.RandomHash().String())
+	appendRefLink(l, "", uuid.NewV4().String(), testutil.RandomHash().String())
 	testLinkValidateError(t, l, nil, "link.meta.refs[0].process should be a non empty string")
+}
+
+func TestLinkValidate_refBadMapID(t *testing.T) {
+	l := cstesting.RandomLink()
+	appendRefLink(l, testutil.RandomString(24), "test", testutil.RandomHash().String())
+	testLinkValidateError(t, l, nil, "link.meta.refs[0].mapId should be a valid UUID V4")
 }
 
 func TestLinkValidate_refMissingLinkHash(t *testing.T) {
 	l := cstesting.RandomLink()
-	appendRefLink(l, testutil.RandomString(24), "")
+	appendRefLink(l, testutil.RandomString(24), uuid.NewV4().String(), "")
 	testLinkValidateError(t, l, nil, "link.meta.refs[0].linkHash should be a bytes32 field")
 }
 
 func TestLinkValidate_refLinkHashBadType(t *testing.T) {
 	l := cstesting.RandomLink()
-	appendRefLink(l, testutil.RandomString(24), "FooBar")
+	appendRefLink(l, testutil.RandomString(24), uuid.NewV4().String(), "FooBar")
 	testLinkValidateError(t, l, nil, "link.meta.refs[0].linkHash should be a bytes32 field")
 }
 
 func TestLinkValidate_refGoodLinkNotChecked(t *testing.T) {
 	l := cstesting.RandomLink()
-	appendRefLink(l, l.Meta.Process, testutil.RandomHash().String())
+	appendRefLink(l, l.Meta.Process, uuid.NewV4().String(), testutil.RandomHash().String())
 	err := l.Validate(context.Background(), nil)
 	assert.NoError(t, err)
 }
 
 func TestLinkValidate_refGoodLinkChecked(t *testing.T) {
 	l := cstesting.RandomLink()
-	appendRefLink(l, l.Meta.Process, testutil.RandomHash().String())
+	appendRefLink(l, l.Meta.Process, uuid.NewV4().String(), testutil.RandomHash().String())
 	err := l.Validate(context.Background(), func(_ context.Context, linkHash *types.Bytes32) (*cs.Segment, error) {
 		return cstesting.RandomSegment(), nil
 	})
@@ -175,7 +182,7 @@ func TestLinkValidate_refGoodLinkChecked(t *testing.T) {
 
 func TestLinkValidate_refGoodLinkNotFound(t *testing.T) {
 	l := cstesting.RandomLink()
-	appendRefLink(l, l.Meta.Process, testutil.RandomHash().String())
+	appendRefLink(l, l.Meta.Process, uuid.NewV4().String(), testutil.RandomHash().String())
 	testLinkValidateErrorWrapper(t, l, func(_ context.Context, linkHash *types.Bytes32) (*cs.Segment, error) {
 		return nil, errors.New("Bad mood")
 	}, "Bad mood")
@@ -183,7 +190,7 @@ func TestLinkValidate_refGoodLinkNotFound(t *testing.T) {
 
 func TestLinkValidate_refGoodNilLink(t *testing.T) {
 	l := cstesting.RandomLink()
-	appendRefLink(l, l.Meta.Process, testutil.RandomHash().String())
+	appendRefLink(l, l.Meta.Process, uuid.NewV4().String(), testutil.RandomHash().String())
 	testLinkValidateError(t, l, func(_ context.Context, linkHash *types.Bytes32) (*cs.Segment, error) {
 		return nil, nil
 	}, "link.meta.refs[0] segment is nil")

--- a/cs/util_test.go
+++ b/cs/util_test.go
@@ -46,9 +46,10 @@ func appendRefSegment(l, ref *cs.Link) {
 	l.Meta.Refs = append(l.Meta.Refs, cs.SegmentReference{Segment: ref.Segmentify()})
 }
 
-func appendRefLink(l *cs.Link, process, linkHash string) {
+func appendRefLink(l *cs.Link, process, mapID, linkHash string) {
 	l.Meta.Refs = append(l.Meta.Refs, cs.SegmentReference{
 		Process:  process,
 		LinkHash: linkHash,
+		MapID:    mapID,
 	})
 }

--- a/tmpop/tmpoptestcases/transaction.go
+++ b/tmpop/tmpoptestcases/transaction.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	uuid "github.com/satori/go.uuid"
 	"github.com/stratumn/go-indigocore/cs"
 	"github.com/stratumn/go-indigocore/cs/cstesting"
 	"github.com/stratumn/go-indigocore/store"
@@ -43,6 +44,7 @@ func (f Factory) TestCheckTx(t *testing.T) {
 		link := cstesting.RandomLink()
 		link.Meta.Refs = []cs.SegmentReference{cs.SegmentReference{
 			Process:  "proc",
+			MapID:    uuid.NewV4().String(),
 			LinkHash: "invalidLinkHash",
 		}}
 		tx := makeCreateLinkTx(t, link)
@@ -60,6 +62,7 @@ func (f Factory) TestCheckTx(t *testing.T) {
 		linkWithRef := cstesting.RandomLinkWithProcess(link.Meta.Process)
 		linkWithRef.Meta.Refs = []cs.SegmentReference{cs.SegmentReference{
 			Process:  link.Meta.Process,
+			MapID:    uuid.NewV4().String(),
 			LinkHash: linkHash.String(),
 		}}
 		tx = makeCreateLinkTx(t, linkWithRef)
@@ -92,6 +95,7 @@ func (f Factory) TestDeliverTx(t *testing.T) {
 		linkWithRef := cstesting.RandomLinkWithProcess(link.Meta.Process)
 		linkWithRef.Meta.Refs = []cs.SegmentReference{cs.SegmentReference{
 			Process:  link.Meta.Process,
+			MapID:    uuid.NewV4().String(),
 			LinkHash: linkHash.String(),
 		}}
 		tx = makeCreateLinkTx(t, linkWithRef)


### PR DESCRIPTION
I wonder how we managed not to spot that before !

By the way, do you think it's relevant to add the full segment in the ref only if the latter belongs to a different process  ? (that would be client-side of course)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/go-indigocore/388)
<!-- Reviewable:end -->
