### PR TITLE
Improve docker image generation performance

### DIFF
--- a/Dockerfile.tpl
+++ b/Dockerfile.tpl
@@ -6,7 +6,7 @@ RUN addgroup -S -g 999 stratumn
 RUN adduser -H -D -u 999 -G stratumn stratumn
 
 COPY LICENSE /usr/local/stratumn/
-COPY dist/linux-amd64/{{CMD}} /usr/local/stratumn/bin/
+COPY {{CMD}} /usr/local/stratumn/bin/
 
 RUN mkdir /usr/local/bin
 RUN ln -s /usr/local/stratumn/bin/{{CMD}} /usr/local/bin/{{CMD}}


### PR DESCRIPTION
When docker creates its context to create images, it takes a while because context is built from the root project directory.

Performance:
```
before: make docker_images  65.38s user 91.98s system 34% cpu 7:34.37 total
after:  make docker_images  19.54s user 12.71s system 53% cpu 59.871 total
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/go-indigocore/391)
<!-- Reviewable:end -->
