### PR TITLE
monitoring: update metrics name

### DIFF
--- a/batchfossilizer/metrics.go
+++ b/batchfossilizer/metrics.go
@@ -40,13 +40,13 @@ func init() {
 	)
 	if err := view.Register(
 		&view.View{
-			Name:        "stratumn_batchfossilizer_batch_count",
+			Name:        "stratumn_indigocore _batchfossilizer_batch_count",
 			Description: "number of batches sent",
 			Measure:     batchCount,
 			Aggregation: view.Count(),
 		},
 		&view.View{
-			Name:        "stratumn_batchfossilizer_fossilized_links_count",
+			Name:        "stratumn_indigocore_batchfossilizer_fossilized_links_count",
 			Description: "number of links fossilized",
 			Measure:     fossilizedLinksCount,
 			Aggregation: view.Count(),

--- a/batchfossilizer/metrics.go
+++ b/batchfossilizer/metrics.go
@@ -40,13 +40,13 @@ func init() {
 	)
 	if err := view.Register(
 		&view.View{
-			Name:        "batch_count",
+			Name:        "stratumn_batchfossilizer_batch_count",
 			Description: "number of batches sent",
 			Measure:     batchCount,
 			Aggregation: view.Count(),
 		},
 		&view.View{
-			Name:        "fossilized_links_count",
+			Name:        "stratumn_batchfossilizer_fossilized_links_count",
 			Description: "number of links fossilized",
 			Measure:     fossilizedLinksCount,
 			Aggregation: view.Count(),

--- a/bufferedbatch/metrics.go
+++ b/bufferedbatch/metrics.go
@@ -55,20 +55,20 @@ func init() {
 
 	if err = view.Register(
 		&view.View{
-			Name:        "stratumn_bufferedbatch_batch_count",
+			Name:        "stratumn_indigocore_bufferedbatch_batch_count",
 			Description: "number of batches created",
 			Measure:     batchCount,
 			Aggregation: view.Count(),
 		},
 		&view.View{
-			Name:        "stratumn_bufferedbatch_write_count",
+			Name:        "stratumn_indigocore_bufferedbatch_write_count",
 			Description: "number of batch writes",
 			Measure:     writeCount,
 			Aggregation: view.Count(),
 			TagKeys:     []tag.Key{writeStatus},
 		},
 		&view.View{
-			Name:        "stratumn_bufferedbatch_links_per_batch",
+			Name:        "stratumn_indigocore_bufferedbatch_links_per_batch",
 			Description: "number of links per batch",
 			Measure:     linksPerBatch,
 			Aggregation: view.Distribution(1, 5, 10, 50, 100),

--- a/bufferedbatch/metrics.go
+++ b/bufferedbatch/metrics.go
@@ -55,20 +55,20 @@ func init() {
 
 	if err = view.Register(
 		&view.View{
-			Name:        "batch_count",
+			Name:        "stratumn_bufferedbatch_batch_count",
 			Description: "number of batches created",
 			Measure:     batchCount,
 			Aggregation: view.Count(),
 		},
 		&view.View{
-			Name:        "write_count",
+			Name:        "stratumn_bufferedbatch_write_count",
 			Description: "number of batch writes",
 			Measure:     writeCount,
 			Aggregation: view.Count(),
 			TagKeys:     []tag.Key{writeStatus},
 		},
 		&view.View{
-			Name:        "links_per_batch",
+			Name:        "stratumn_bufferedbatch_links_per_batch",
 			Description: "number of links per batch",
 			Measure:     linksPerBatch,
 			Aggregation: view.Distribution(1, 5, 10, 50, 100),

--- a/tmpop/metrics.go
+++ b/tmpop/metrics.go
@@ -65,20 +65,20 @@ func init() {
 
 	if err = view.Register(
 		&view.View{
-			Name:        "block_count",
+			Name:        "stratumn_tmpop_block_count",
 			Description: "number of blocks created",
 			Measure:     blockCount,
 			Aggregation: view.Count(),
 		},
 		&view.View{
-			Name:        "tx_count",
+			Name:        "stratumn_tmpop_tx_count",
 			Description: "number of transactions received",
 			Measure:     txCount,
 			Aggregation: view.Count(),
 			TagKeys:     []tag.Key{txStatus},
 		},
 		&view.View{
-			Name:        "tx_per_block",
+			Name:        "stratumn_tmpop_tx_per_block",
 			Description: "number of transactions per block",
 			Measure:     txPerBlock,
 			Aggregation: view.Distribution(1, 5, 10, 50, 100),

--- a/tmpop/metrics.go
+++ b/tmpop/metrics.go
@@ -65,20 +65,20 @@ func init() {
 
 	if err = view.Register(
 		&view.View{
-			Name:        "stratumn_tmpop_block_count",
+			Name:        "stratumn_indigocore_tmpop_block_count",
 			Description: "number of blocks created",
 			Measure:     blockCount,
 			Aggregation: view.Count(),
 		},
 		&view.View{
-			Name:        "stratumn_tmpop_tx_count",
+			Name:        "stratumn_indigocore_tmpop_tx_count",
 			Description: "number of transactions received",
 			Measure:     txCount,
 			Aggregation: view.Count(),
 			TagKeys:     []tag.Key{txStatus},
 		},
 		&view.View{
-			Name:        "stratumn_tmpop_tx_per_block",
+			Name:        "stratumn_indigocore_tmpop_tx_per_block",
 			Description: "number of transactions per block",
 			Measure:     txPerBlock,
 			Aggregation: view.Distribution(1, 5, 10, 50, 100),


### PR DESCRIPTION
The latest opencensus changes removed the previous "opencensus_" prefix.
I'm taking advantage of that to properly name our views (following what looks like the best practice for prometheus views).
Thanks for catching that!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/go-indigocore/392)
<!-- Reviewable:end -->
