### PR TITLE
batch: remove link validation in CreateLink

### DIFF
--- a/bufferedbatch/batch.go
+++ b/bufferedbatch/batch.go
@@ -47,9 +47,6 @@ func (b *Batch) CreateLink(ctx context.Context, link *cs.Link) (_ *types.Bytes32
 	ctx, span := trace.StartSpan(ctx, "bufferedbatch/CreateLink")
 	defer monitoring.SetSpanStatusAndEnd(span, err)
 
-	if err := link.Validate(ctx, b.GetSegment); err != nil {
-		return nil, err
-	}
 	b.Links = append(b.Links, link)
 	return link.Hash()
 }


### PR DESCRIPTION
Bufferedbatch's CreateLink is validating the link for no reason.
All other store don't do any validation, their only responsibility is to store links.
Validation is done beforehand (in the http server for http store or in TMPoP when receiving links via DeliverTx).
Refactored bufferedbatch tests to use assertions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/go-indigocore/406)
<!-- Reviewable:end -->
