### PR TITLE
cs: remove including full segment in ref

### DIFF
--- a/agent/client/utils_test.go
+++ b/agent/client/utils_test.go
@@ -25,11 +25,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
-
 	"github.com/golang/mock/gomock"
 	"github.com/gorilla/mux"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 	"github.com/stratumn/go-indigocore/agent"
 	"github.com/stratumn/go-indigocore/agent/agenttestcases"
 	"github.com/stratumn/go-indigocore/agent/client"
@@ -62,23 +61,16 @@ func (m *mockHTTPServer) decodeRefs(input interface{}) ([]cs.SegmentReference, e
 		if !ok {
 			return nil, errors.Errorf("refs[%d] should be a map", refIdx)
 		}
-		if jsonSeg, ok := ref["segment"].(string); ok {
-			var seg cs.Segment
-			if err := json.Unmarshal([]byte(jsonSeg), &seg); err != nil {
-				return nil, errors.Errorf("refs[%d].segment should be a valid json segment", refIdx)
-			}
-			refs = append(refs, cs.SegmentReference{Segment: &seg})
-		} else {
-			process, ok := ref["process"].(string)
-			if !ok || process == "" {
-				return nil, errors.Errorf("refs[%d].process should be a non empty string", refIdx)
-			}
-			linkHashStr, ok := ref["linkHash"].(string)
-			if !ok || linkHashStr == "" {
-				return nil, errors.Errorf("refs[%d].linkHash should be a non empty string", refIdx)
-			}
-			refs = append(refs, cs.SegmentReference{Process: process, LinkHash: linkHashStr})
+
+		process, ok := ref["process"].(string)
+		if !ok || process == "" {
+			return nil, errors.Errorf("refs[%d].process should be a non empty string", refIdx)
 		}
+		linkHashStr, ok := ref["linkHash"].(string)
+		if !ok || linkHashStr == "" {
+			return nil, errors.Errorf("refs[%d].linkHash should be a non empty string", refIdx)
+		}
+		refs = append(refs, cs.SegmentReference{Process: process, LinkHash: linkHashStr})
 	}
 	return refs, nil
 }

--- a/cs/cs_test.go
+++ b/cs/cs_test.go
@@ -123,22 +123,6 @@ func TestLinkValidate_tagsEmpty(t *testing.T) {
 	testLinkValidateError(t, l, nil, "link.meta.tags should be an array of non empty string")
 }
 
-func TestLinkValidate_refGoodLink(t *testing.T) {
-	l := cstesting.RandomLink()
-	ref := cstesting.RandomLink()
-	appendRefSegment(l, ref)
-	err := l.Validate(context.Background(), nil)
-	assert.NoError(t, err, "l.Validate()")
-}
-
-func TestLinkValidate_refBadLink(t *testing.T) {
-	l := cstesting.RandomLink()
-	ref := cstesting.RandomLink()
-	ref.Meta.Process = ""
-	appendRefSegment(l, ref)
-	testLinkValidateErrorWrapper(t, l, nil, "invalid link.meta.refs[0].segment")
-}
-
 func TestLinkValidate_refMissingProcess(t *testing.T) {
 	l := cstesting.RandomLink()
 	appendRefLink(l, "", testutil.RandomHash().String())

--- a/cs/cstesting/builder.go
+++ b/cs/cstesting/builder.go
@@ -70,7 +70,7 @@ func (lb *LinkBuilder) WithTag(tag string) *LinkBuilder {
 	return lb
 }
 
-// WithTags fills the link's tags.
+// WithTags replaces the link's tags.
 func (lb *LinkBuilder) WithTags(tags ...string) *LinkBuilder {
 	lb.Link.Meta.Tags = tags
 	return lb
@@ -100,14 +100,6 @@ func (lb *LinkBuilder) WithRef(link *cs.Link) *LinkBuilder {
 	lb.Link.Meta.Refs = append(lb.Link.Meta.Refs, cs.SegmentReference{
 		LinkHash: refHash,
 		Process:  link.Meta.Process,
-	})
-	return lb
-}
-
-// WithSegmentRef adds a reference to the link by fully including the segment.
-func (lb *LinkBuilder) WithSegmentRef(s *cs.Segment) *LinkBuilder {
-	lb.Link.Meta.Refs = append(lb.Link.Meta.Refs, cs.SegmentReference{
-		Segment: s,
 	})
 	return lb
 }

--- a/cs/util_test.go
+++ b/cs/util_test.go
@@ -42,10 +42,6 @@ func testLinkValidateErrorWrapper(t *testing.T, l *cs.Link, getSegment cs.GetSeg
 	innerTestLinkValidate(t, l, getSegment, want, strings.Contains)
 }
 
-func appendRefSegment(l, ref *cs.Link) {
-	l.Meta.Refs = append(l.Meta.Refs, cs.SegmentReference{Segment: ref.Segmentify()})
-}
-
 func appendRefLink(l *cs.Link, process, linkHash string) {
 	l.Meta.Refs = append(l.Meta.Refs, cs.SegmentReference{
 		Process:  process,


### PR DESCRIPTION
As discussed offline, removing this feature.
When we need to reference links from other stores, we'll rethink the approach depending on the usecase.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/go-indigocore/409)
<!-- Reviewable:end -->
