### PR TITLE
batchfossilizer: add interface

### DIFF
--- a/bcbatchfossilizer/bcbatchfossilizer.go
+++ b/bcbatchfossilizer/bcbatchfossilizer.go
@@ -53,7 +53,7 @@ type Info struct {
 }
 
 // Fossilizer is the type that
-// implements github.com/stratumn/go-indigocore/fossilizer.Adapter.
+// implements github.com/stratumn/go-indigocore/batchfossilizer.Adapter.
 type Fossilizer struct {
 	*batchfossilizer.Fossilizer
 	config            *Config


### PR DESCRIPTION
This is useful to mock the behavior of a batch fossilizer in alice.