### PR TITLE
validation: add interface to GovernanceManager

### DIFF
--- a/tmpop/state.go
+++ b/tmpop/state.go
@@ -99,8 +99,8 @@ func (s *State) checkLinkAndAddToBatch(ctx context.Context, link *cs.Link, batch
 		}
 	}
 
-	if validator := s.governance.Current(); validator != nil {
-		err = validator.Validate(ctx, batch, link)
+	if s.validator != nil {
+		err = s.validator.Validate(ctx, batch, link)
 		if err != nil {
 			return &ABCIError{
 				CodeTypeValidation,

--- a/tmpop/state.go
+++ b/tmpop/state.go
@@ -41,7 +41,7 @@ type State struct {
 	deliveredLinksList []*cs.Link
 	checkedLinks       store.Batch
 
-	governance *validator.GovernanceManager
+	governance validator.GovernanceManager
 }
 
 // NewState creates a new State.
@@ -61,17 +61,18 @@ func NewState(ctx context.Context, a store.Adapter, config *Config) (*State, err
 		checkedLinks:   checkedLinks,
 	}
 
-	state.governance, err = validator.NewGovernanceManager(ctx, a, config.Validation)
+	state.governance, err = validator.NewLocalGovernor(ctx, a, config.Validation)
 	if err != nil {
 		return nil, err
 	}
+	go state.governance.ListenAndUpdate(ctx)
 
 	return state, nil
 }
 
 // UpdateValidators updates validators if a new version is available
 func (s *State) UpdateValidators(ctx context.Context) {
-	s.governance.UpdateValidators(ctx, &s.validator)
+	s.validator = s.governance.Current()
 }
 
 // Check checks if creating this link is a valid operation
@@ -98,8 +99,8 @@ func (s *State) checkLinkAndAddToBatch(ctx context.Context, link *cs.Link, batch
 		}
 	}
 
-	if s.validator != nil {
-		err = s.validator.Validate(ctx, batch, link)
+	if validator := s.governance.Current(); validator != nil {
+		err = validator.Validate(ctx, batch, link)
 		if err != nil {
 			return &ABCIError{
 				CodeTypeValidation,


### PR DESCRIPTION
I added an interface to the governanceManager in order to be able to mock it and to add new implementations (apart from picking updates from a local file).

I modified the behavior of the manager to run it in a goroutine and receive updates whenever it's available.

Do you think it should live it should live in its own package ?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/go-indigocore/413)
<!-- Reviewable:end -->
