### PR TITLE
add network validation manager

### DIFF
--- a/validation/broadcaster.go
+++ b/validation/broadcaster.go
@@ -17,7 +17,6 @@ package validation
 import (
 	"sync"
 
-	"github.com/stratumn/alice/core/protocol/coin/validator"
 	"github.com/stratumn/go-indigocore/validation/validators"
 )
 
@@ -29,7 +28,7 @@ type UpdateSubscriber interface {
 
 // UpdateNotifier allows broadcasting a validator to a bunch of subscribers.
 type UpdateNotifier interface {
-	Broadcast(validator.Validator)
+	Broadcast(validators.Validator)
 	Close()
 }
 

--- a/validation/broadcaster.go
+++ b/validation/broadcaster.go
@@ -1,0 +1,86 @@
+// Copyright 2017 Stratumn SAS. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validation
+
+import (
+	"sync"
+
+	"github.com/stratumn/go-indigocore/validation/validators"
+)
+
+// Broadcaster provides subscription to a Manager to be notified of validation updates.
+type Broadcaster struct {
+	current validators.Validator
+
+	listenersMutex sync.RWMutex
+	listeners      []chan validators.Validator
+}
+
+// AddListener return a listener that will be notified when the validator changes.
+func (b *Broadcaster) AddListener() <-chan validators.Validator {
+	b.listenersMutex.Lock()
+	defer b.listenersMutex.Unlock()
+
+	subscribeChan := make(chan validators.Validator)
+	b.listeners = append(b.listeners, subscribeChan)
+	// Insert the current validator in the channel if there is one.
+	if b.current != nil {
+		go func() {
+			subscribeChan <- b.current
+		}()
+	}
+	return subscribeChan
+}
+
+// RemoveListener removes a listener.
+func (b *Broadcaster) RemoveListener(c <-chan validators.Validator) {
+	b.listenersMutex.Lock()
+	defer b.listenersMutex.Unlock()
+
+	index := -1
+	for i, l := range b.listeners {
+		if l == c {
+			index = i
+			break
+		}
+	}
+
+	if index >= 0 {
+		close(b.listeners[index])
+		b.listeners[index] = b.listeners[len(b.listeners)-1]
+		b.listeners = b.listeners[:len(b.listeners)-1]
+	}
+}
+
+func (b *Broadcaster) broadcast(validator validators.Validator) {
+	b.listenersMutex.RLock()
+	defer b.listenersMutex.RUnlock()
+
+	b.current = validator
+	for _, listener := range b.listeners {
+		go func(listener chan validators.Validator) {
+			listener <- validator
+		}(listener)
+	}
+}
+
+func (b *Broadcaster) closeListeners() {
+	b.listenersMutex.Lock()
+	defer b.listenersMutex.Unlock()
+
+	for _, s := range b.listeners {
+		close(s)
+	}
+}

--- a/validation/broadcaster_test.go
+++ b/validation/broadcaster_test.go
@@ -1,0 +1,60 @@
+// Copyright 2017 Stratumn SAS. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validation
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stratumn/go-indigocore/validation/validators"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBroadcaster(t *testing.T) {
+
+	validator := validators.NewMultiValidator(nil)
+
+	t.Run("AddRemoveListener", func(t *testing.T) {
+		t.Run("Adds a listener provided with the current valitor set", func(t *testing.T) {
+
+			b := Broadcaster{}
+			b.broadcast(validator)
+
+			select {
+			case <-b.AddListener():
+				break
+			case <-time.After(10 * time.Millisecond):
+				t.Error("No validator in the channel")
+			}
+		})
+
+		t.Run("Removes an unknown channel", func(t *testing.T) {
+			b := Broadcaster{}
+			b.RemoveListener(make(chan validators.Validator))
+			b.AddListener()
+			b.RemoveListener(make(chan validators.Validator))
+		})
+
+		t.Run("Removes closes the channel", func(t *testing.T) {
+			b := Broadcaster{}
+			listener := b.AddListener()
+			b.RemoveListener(listener)
+
+			_, ok := <-listener
+			assert.False(t, ok, "<-listener")
+		})
+	})
+
+}

--- a/validation/broadcaster_test.go
+++ b/validation/broadcaster_test.go
@@ -26,7 +26,7 @@ func TestBroadcaster(t *testing.T) {
 
 	validator := validators.NewMultiValidator(nil)
 
-	t.Run("Subscribe-Unsubscribe", func(t *testing.T) {
+	t.Run("Subscribe", func(t *testing.T) {
 		t.Run("Adds a listener provided with the current validator set", func(t *testing.T) {
 
 			b := NewUpdateBroadcaster()
@@ -39,6 +39,8 @@ func TestBroadcaster(t *testing.T) {
 				assert.Fail(t, "No validator in the channel")
 			}
 		})
+	})
+	t.Run("Unsubscribe", func(t *testing.T) {
 
 		t.Run("Removes an unknown channel", func(t *testing.T) {
 			b := NewUpdateBroadcaster()
@@ -50,7 +52,7 @@ func TestBroadcaster(t *testing.T) {
 			b.Unsubscribe(make(chan validators.Validator))
 		})
 
-		t.Run("Removes closes the channel", func(t *testing.T) {
+		t.Run("Closes the channel", func(t *testing.T) {
 			b := NewUpdateBroadcaster()
 			listener := b.Subscribe()
 			b.Unsubscribe(listener)
@@ -58,6 +60,7 @@ func TestBroadcaster(t *testing.T) {
 			_, ok := <-listener
 			assert.False(t, ok, "<-listener")
 		})
+
 	})
 
 	t.Run("Broadcast", func(t *testing.T) {

--- a/validation/configloader.go
+++ b/validation/configloader.go
@@ -85,7 +85,7 @@ func LoadConfigContent(data []byte, pluginsPath string, listener rulesListener) 
 // The configuration returned can then be used in NewMultiValidator().
 func LoadProcessRules(schema *RulesSchema, process, pluginsPath string, listener rulesListener) (validators.Validators, error) {
 	if err := checkPKIConfig(schema.PKI); err != nil {
-		return nil, errors.WithStack(err)
+		return nil, err
 	}
 
 	processValidators, err := loadValidatorsConfig(process, pluginsPath, schema.Types, schema.PKI)

--- a/validation/configloader.go
+++ b/validation/configloader.go
@@ -39,7 +39,7 @@ type processesRules map[string]RulesSchema
 
 // RulesSchema represents the structure of validation rules.
 type RulesSchema struct {
-	PKI   validators.PKI        `json:"pki"`
+	PKI   *validators.PKI       `json:"pki"`
 	Types map[string]TypeSchema `json:"types"`
 }
 
@@ -47,7 +47,7 @@ type rulesListener func(process string, schema RulesSchema, validators validator
 
 // LoadConfig loads the validators configuration from a json file.
 // The configuration returned can then be used in NewMultiValidator().
-func LoadConfig(validationCfg *Config, listener rulesListener) (validators.Validators, error) {
+func LoadConfig(validationCfg *Config, listener rulesListener) (validators.ProcessesValidators, error) {
 	f, err := os.Open(validationCfg.RulesPath)
 	if err != nil {
 		return nil, errors.WithStack(err)
@@ -63,7 +63,7 @@ func LoadConfig(validationCfg *Config, listener rulesListener) (validators.Valid
 
 // LoadConfigContent loads the validators configuration from json data.
 // The configuration returned can then be used in NewMultiValidator().
-func LoadConfigContent(data []byte, pluginsPath string, listener rulesListener) (validators.Validators, error) {
+func LoadConfigContent(data []byte, pluginsPath string, listener rulesListener) (validators.ProcessesValidators, error) {
 	var rules processesRules
 	err := json.Unmarshal(data, &rules)
 	if err != nil {
@@ -74,32 +74,32 @@ func LoadConfigContent(data []byte, pluginsPath string, listener rulesListener) 
 
 // LoadProcessRules loads the validators configuration from a slice of processRule.
 // The configuration returned can then be used in NewMultiValidator().
-func LoadProcessRules(rules processesRules, pluginsPath string, listener rulesListener) (validators.Validators, error) {
-	var validators validators.Validators
+func LoadProcessRules(rules processesRules, pluginsPath string, listener rulesListener) (validators.ProcessesValidators, error) {
+	validators := make(validators.ProcessesValidators, 0)
 	for process, schema := range rules {
 		if err := checkPKIConfig(schema.PKI); err != nil {
 			return nil, errors.WithStack(err)
 		}
 
-		processValidators, err := loadValidatorsConfig(process, pluginsPath, schema.Types, &schema.PKI)
+		processValidators, err := loadValidatorsConfig(process, pluginsPath, schema.Types, schema.PKI)
 		if err != nil {
 			return nil, err
 		}
 		if listener != nil {
 			listener(process, schema, processValidators)
 		}
-		validators = append(validators, processValidators...)
+		validators[process] = processValidators
 	}
 	return validators, nil
 }
 
 // checkPKIConfig checks that public keys are base64 encoded.
-func checkPKIConfig(data validators.PKI) error {
+func checkPKIConfig(data *validators.PKI) error {
 	if data == nil {
 		return nil
 	}
 
-	for _, id := range data {
+	for _, id := range *data {
 		for _, key := range id.Keys {
 			if _, err := keys.ParsePublicKey([]byte(key)); err != nil {
 				return errors.Wrapf(err, "error while parsing public key [%s]", key)

--- a/validation/configloader_test.go
+++ b/validation/configloader_test.go
@@ -89,7 +89,7 @@ func TestLoadConfig_Success(t *testing.T) {
 		validators, err := validation.LoadConfig(&validation.Config{
 			RulesPath:   testFile,
 			PluginsPath: pluginsPath,
-		}, func(process string, schema validation.RulesSchema, processValidators validators.Validators) {
+		}, func(process string, schema *validation.RulesSchema, processValidators validators.Validators) {
 			validatorProcessCount++
 			validatorCount = validatorCount + len(processValidators)
 		})

--- a/validation/configloader_test.go
+++ b/validation/configloader_test.go
@@ -56,22 +56,24 @@ func TestLoadConfig_Success(t *testing.T) {
 	t.Run("schema & signatures & transitions & plugins", func(T *testing.T) {
 		testFile := utils.CreateTempFile(t, testutils.ValidJSONConfig)
 		defer os.Remove(testFile)
-		validatorList, err := validation.LoadConfig(&validation.Config{
+		validatorMap, err := validation.LoadConfig(&validation.Config{
 			RulesPath:   testFile,
 			PluginsPath: pluginsPath,
 		}, nil)
 
 		assert.NoError(t, err, "LoadConfig()")
-		assert.NotNil(t, validatorList)
+		assert.NotNil(t, validatorMap)
 
 		var schemaValidatorCount, pkiValidatorCount, transitionValidatorCount int
-		for _, v := range validatorList {
-			if _, ok := v.(*validators.PKIValidator); ok {
-				pkiValidatorCount++
-			} else if _, ok := v.(*validators.SchemaValidator); ok {
-				schemaValidatorCount++
-			} else if _, ok := v.(*validators.TransitionValidator); ok {
-				transitionValidatorCount++
+		for _, validatorList := range validatorMap {
+			for _, v := range validatorList {
+				if _, ok := v.(*validators.PKIValidator); ok {
+					pkiValidatorCount++
+				} else if _, ok := v.(*validators.SchemaValidator); ok {
+					schemaValidatorCount++
+				} else if _, ok := v.(*validators.TransitionValidator); ok {
+					transitionValidatorCount++
+				}
 			}
 		}
 		assert.Equal(t, 3, schemaValidatorCount)
@@ -87,15 +89,17 @@ func TestLoadConfig_Success(t *testing.T) {
 		validators, err := validation.LoadConfig(&validation.Config{
 			RulesPath:   testFile,
 			PluginsPath: pluginsPath,
-		}, func(process string, schema validation.RulesSchema, validators validators.Validators) {
+		}, func(process string, schema validation.RulesSchema, processValidators validators.Validators) {
 			validatorProcessCount++
-			validatorCount = validatorCount + len(validators)
+			validatorCount = validatorCount + len(processValidators)
 		})
 		assert.NoError(t, err, "LoadConfig()")
 		assert.NotNil(t, validators)
 		assert.Equal(t, 2, validatorProcessCount)
 		assert.Equal(t, 10, validatorCount)
-		assert.Len(t, validators, validatorCount)
+		assert.Len(t, validators, validatorProcessCount)
+		assert.Len(t, validators["chat"], 4)
+		assert.Len(t, validators["auction"], 6)
 	})
 
 	t.Run("Null signatures", func(T *testing.T) {
@@ -121,15 +125,16 @@ func TestLoadConfig_Success(t *testing.T) {
 
 		testFile := utils.CreateTempFile(t, validJSONSig)
 		defer os.Remove(testFile)
-		validatorList, err := validation.LoadConfig(&validation.Config{
+		validatorMap, err := validation.LoadConfig(&validation.Config{
 			RulesPath: testFile,
 		}, nil)
 
 		require.NoError(t, err, "LoadConfig()")
-		assert.NotNil(t, validatorList)
+		assert.NotNil(t, validatorMap)
 
-		require.Len(t, validatorList, 1)
-		assert.IsType(t, &validators.SchemaValidator{}, validatorList[0])
+		require.Len(t, validatorMap, 1)
+		require.Len(t, validatorMap["testProcess"], 1)
+		assert.IsType(t, &validators.SchemaValidator{}, validatorMap["testProcess"][0])
 	})
 
 	t.Run("Empty signatures", func(T *testing.T) {
@@ -155,15 +160,16 @@ func TestLoadConfig_Success(t *testing.T) {
 
 		testFile := utils.CreateTempFile(t, validJSONSig)
 		defer os.Remove(testFile)
-		validatorList, err := validation.LoadConfig(&validation.Config{
+		validatorMap, err := validation.LoadConfig(&validation.Config{
 			RulesPath: testFile,
 		}, nil)
 
 		require.NoError(t, err, "LoadConfig()")
-		assert.NotNil(t, validatorList)
+		assert.NotNil(t, validatorMap)
 
-		require.Len(t, validatorList, 1)
-		assert.IsType(t, &validators.SchemaValidator{}, validatorList[0])
+		require.Len(t, validatorMap, 1)
+		require.Len(t, validatorMap["test"], 1)
+		assert.IsType(t, &validators.SchemaValidator{}, validatorMap["test"][0])
 	})
 
 	t.Run("No PKI", func(T *testing.T) {
@@ -183,15 +189,16 @@ func TestLoadConfig_Success(t *testing.T) {
 
 		testFile := utils.CreateTempFile(t, validJSONSig)
 		defer os.Remove(testFile)
-		validatorList, err := validation.LoadConfig(&validation.Config{
+		validatorMap, err := validation.LoadConfig(&validation.Config{
 			RulesPath: testFile,
 		}, nil)
 
 		require.NoError(t, err, "LoadConfig()")
-		assert.NotNil(t, validatorList)
+		assert.NotNil(t, validatorMap)
 
-		require.Len(t, validatorList, 1)
-		assert.IsType(t, &validators.SchemaValidator{}, validatorList[0])
+		require.Len(t, validatorMap, 1)
+		require.Len(t, validatorMap["test"], 1)
+		assert.IsType(t, &validators.SchemaValidator{}, validatorMap["test"][0])
 	})
 
 	t.Run("Transitions only", func(T *testing.T) {
@@ -209,15 +216,16 @@ func TestLoadConfig_Success(t *testing.T) {
 
 		testFile := utils.CreateTempFile(t, validJSONSig)
 		defer os.Remove(testFile)
-		validatorList, err := validation.LoadConfig(&validation.Config{
+		validatorMap, err := validation.LoadConfig(&validation.Config{
 			RulesPath: testFile,
 		}, nil)
 
 		require.NoError(t, err, "LoadConfig()")
-		assert.NotNil(t, validatorList)
+		assert.NotNil(t, validatorMap)
 
-		require.Len(t, validatorList, 1)
-		assert.IsType(t, &validators.TransitionValidator{}, validatorList[0])
+		require.Len(t, validatorMap, 1)
+		require.Len(t, validatorMap["test"], 1)
+		assert.IsType(t, &validators.TransitionValidator{}, validatorMap["test"][0])
 	})
 
 }

--- a/validation/localmanager.go
+++ b/validation/localmanager.go
@@ -26,7 +26,7 @@ import (
 
 // LocalManager manages governance for validation rules management in an indigo network.
 type LocalManager struct {
-	*Broadcaster
+	*UpdateBroadcaster
 	store *Store
 
 	validationCfg    *Config
@@ -43,9 +43,9 @@ func NewLocalManager(ctx context.Context, a store.Adapter, validationCfg *Config
 
 	var err error
 	var govMgr = LocalManager{
-		Broadcaster:   &Broadcaster{},
-		store:         NewStore(a, validationCfg),
-		validationCfg: validationCfg,
+		UpdateBroadcaster: NewUpdateBroadcaster(),
+		store:             NewStore(a, validationCfg),
+		validationCfg:     validationCfg,
 	}
 
 	if validationCfg.RulesPath != "" {
@@ -86,7 +86,7 @@ func (m *LocalManager) ListenAndUpdate(ctx context.Context) error {
 			log.Warnf("Validator file watcher error caught: %s", err)
 
 		case <-ctx.Done():
-			m.closeListeners()
+			m.Close()
 			return ctx.Err()
 		}
 	}
@@ -118,5 +118,5 @@ func (m *LocalManager) GetValidators(ctx context.Context) (validators.ProcessesV
 
 func (m *LocalManager) updateCurrent(validatorsMap validators.ProcessesValidators) {
 	m.current = validators.NewMultiValidator(validatorsMap)
-	m.broadcast(m.current)
+	m.Broadcast(m.current)
 }

--- a/validation/localmanager_test.go
+++ b/validation/localmanager_test.go
@@ -130,7 +130,7 @@ func TestLocalManager(t *testing.T) {
 			})
 			require.NotNil(t, gov, "Gouvernance is initialized by file and store")
 			go gov.ListenAndUpdate(ctx)
-			waitValidator := gov.AddListener()
+			waitValidator := gov.Subscribe()
 			v = <-waitValidator
 			assert.NotNil(t, v, "Validator loaded from file")
 
@@ -205,7 +205,7 @@ func TestLocalManager(t *testing.T) {
 			assert.Nil(t, gov.Current())
 
 			ioutil.WriteFile(testFile, []byte(testutils.ValidJSONConfig), os.ModeTemporary)
-			newValidator := <-gov.AddListener()
+			newValidator := <-gov.Subscribe()
 			assert.Equal(t, newValidator, gov.Current())
 		})
 	})

--- a/validation/localmanager_test.go
+++ b/validation/localmanager_test.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/stratumn/go-indigocore/dummystore"
 	"github.com/stratumn/go-indigocore/store/storetesting"
@@ -119,7 +118,7 @@ func TestLocalManager(t *testing.T) {
 	})
 
 	t.Run("ListenAndUpdate", func(t *testing.T) {
-		t.Run("New validation file read on modification", func(t *testing.T) {
+		t.Run("Update rules in store on file update", func(t *testing.T) {
 			var v validators.Validator
 			ctx := context.Background()
 			validJSON := fmt.Sprintf(`{%s}`, testutils.ValidChatJSONConfig)
@@ -157,7 +156,7 @@ func TestLocalManager(t *testing.T) {
 
 		t.Run("closes subscribing channels on context cancel", func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
+
 			testFile := utils.CreateTempFile(t, testutils.ValidJSONConfig)
 			defer os.Remove(testFile)
 			gov, err := validation.NewLocalManager(ctx, dummystore.New(nil), &validation.Config{
@@ -165,9 +164,14 @@ func TestLocalManager(t *testing.T) {
 				PluginsPath: pluginsPath,
 			})
 			require.NoError(t, err)
+
+			done := make(chan struct{})
 			go func() {
 				require.EqualError(t, gov.ListenAndUpdate(ctx), context.Canceled.Error())
+				done <- struct{}{}
 			}()
+			cancel()
+			<-done
 		})
 
 		t.Run("return an error when no file watcher is set", func(t *testing.T) {
@@ -176,9 +180,13 @@ func TestLocalManager(t *testing.T) {
 			defer os.Remove(testFile)
 			gov, err := validation.NewLocalManager(ctx, dummystore.New(nil), &validation.Config{})
 			require.NoError(t, err)
+
+			done := make(chan struct{})
 			go func() {
 				require.EqualError(t, gov.ListenAndUpdate(ctx), validation.ErrNoFileWatcher.Error())
+				done <- struct{}{}
 			}()
+			<-done
 		})
 	})
 
@@ -199,43 +207,6 @@ func TestLocalManager(t *testing.T) {
 			ioutil.WriteFile(testFile, []byte(testutils.ValidJSONConfig), os.ModeTemporary)
 			newValidator := <-gov.AddListener()
 			assert.Equal(t, newValidator, gov.Current())
-		})
-	})
-
-	t.Run("AddRemoveListener", func(t *testing.T) {
-		t.Run("Adds a listener provided with the current valitor set", func(t *testing.T) {
-			ctx := context.Background()
-			testFile := utils.CreateTempFile(t, testutils.ValidJSONConfig)
-			defer os.Remove(testFile)
-			gov, err := validation.NewLocalManager(ctx, dummystore.New(nil), &validation.Config{
-				RulesPath:   testFile,
-				PluginsPath: pluginsPath,
-			})
-			require.NoError(t, err)
-			select {
-			case <-gov.AddListener():
-				break
-			case <-time.After(10 * time.Millisecond):
-				t.Error("No validator in the channel")
-			}
-		})
-
-		t.Run("Removes an unknown channel", func(t *testing.T) {
-			ctx := context.Background()
-			gov, _ := validation.NewLocalManager(ctx, dummystore.New(nil), &validation.Config{})
-			gov.RemoveListener(make(chan validators.Validator))
-			gov.AddListener()
-			gov.RemoveListener(make(chan validators.Validator))
-		})
-
-		t.Run("Removes closes the channel", func(t *testing.T) {
-			ctx := context.Background()
-			gov, _ := validation.NewLocalManager(ctx, dummystore.New(nil), &validation.Config{})
-			listener := gov.AddListener()
-			gov.RemoveListener(listener)
-
-			_, ok := <-listener
-			assert.False(t, ok, "<-listener")
 		})
 	})
 }

--- a/validation/networkmanager.go
+++ b/validation/networkmanager.go
@@ -17,33 +17,41 @@ package validation
 import (
 	"context"
 	"encoding/json"
-	"sync"
 
 	"github.com/pkg/errors"
+	"github.com/prometheus/common/log"
 	"github.com/stratumn/go-indigocore/cs"
 	"github.com/stratumn/go-indigocore/store"
 	"github.com/stratumn/go-indigocore/validation/validators"
 )
 
+var (
+	// ErrMissingProcess is the error returned when the ProcessMetaKey could not be found in the link's meta data.
+	ErrMissingProcess = errors.New("governed process name is missing in the link's meta data")
+
+	// ErrNoNetworkListener is returned when the provided channel is nil.
+	ErrNoNetworkListener = errors.New("missing network listener")
+)
+
 // NetworkManager manages governance for validation rules management in an indigo network.
 type NetworkManager struct {
+	*Broadcaster
 	store *Store
 
 	validationCfg *Config
 	current       validators.Validator
 
 	networkListener <-chan *cs.Link
-	listenersMutex  sync.RWMutex
-	listeners       []chan validators.Validator
 }
 
 // NewNetworkManager returns a new NetworManager able to listen to the network and update governance rules.
 func NewNetworkManager(ctx context.Context, a store.Adapter, networkListener <-chan *cs.Link, validationCfg *Config) (Manager, error) {
 	var err error
 	var govMgr = NetworkManager{
+		Broadcaster:     &Broadcaster{},
 		store:           NewStore(a, validationCfg),
-		networkListener: networkListener,
 		validationCfg:   validationCfg,
+		networkListener: networkListener,
 	}
 
 	currentValidators, err := govMgr.store.GetValidators(ctx)
@@ -57,102 +65,76 @@ func NewNetworkManager(ctx context.Context, a store.Adapter, networkListener <-c
 	return &govMgr, nil
 }
 
-func isGovernanceLink(link *cs.Link) bool {
-	return true
-}
-
 // ListenAndUpdate will update the current validators whenever the provided rule file is updated.
 // This method must be run in a goroutine as it will wait for write events on the file.
-func (g *NetworkManager) ListenAndUpdate(ctx context.Context) error {
+func (m *NetworkManager) ListenAndUpdate(ctx context.Context) error {
+	if m.networkListener == nil {
+		return ErrNoNetworkListener
+	}
+
 	for {
 		select {
-		case link := <-g.networkListener:
+		case link := <-m.networkListener:
 			if isGovernanceLink(link) {
-				if validators, err := g.GetValidators(ctx, link); err == nil {
-					g.updateCurrent(validators)
+				if validators, err := m.GetValidators(ctx, link); err == nil {
+					m.updateCurrent(validators)
+				} else {
+					log.Error(err)
 				}
 			}
 
 		case <-ctx.Done():
-			g.listenersMutex.Lock()
-			defer g.listenersMutex.Unlock()
-			for _, s := range g.listeners {
-				close(s)
-			}
+			m.closeListeners()
 			return ctx.Err()
 		}
 	}
 }
 
-// AddListener return a listener that will be notified when the validator changes.
-func (g *NetworkManager) AddListener() <-chan validators.Validator {
-	g.listenersMutex.Lock()
-	defer g.listenersMutex.Unlock()
-
-	subscribeChan := make(chan validators.Validator)
-	g.listeners = append(g.listeners, subscribeChan)
-
-	// Insert the current validator in the channel if there is one.
-	if g.current != nil {
-		go func() {
-			subscribeChan <- g.current
-		}()
-	}
-	return subscribeChan
-}
-
 // GetValidators extract the config from a link, parses it and returns as list of validators.
-func (g *NetworkManager) GetValidators(ctx context.Context, link *cs.Link) (processesValidators validators.ProcessesValidators, err error) {
+func (m *NetworkManager) GetValidators(ctx context.Context, link *cs.Link) (validators.ProcessesValidators, error) {
 	jsonRules, err := json.Marshal(link.State)
 	if err != nil {
 		return nil, err
 	}
-
-	processRulesUpdate := func(process string, schema RulesSchema, validators validators.Validators) {
-		g.store.UpdateValidator(ctx, process, schema)
-		processesValidators[process] = validators
-	}
-	if _, err = LoadConfigContent(jsonRules, g.validationCfg.PluginsPath, processRulesUpdate); err != nil {
+	var schema RulesSchema
+	if err := json.Unmarshal(jsonRules, &schema); err != nil {
 		return nil, err
 	}
 
-	return processesValidators, nil
-}
-
-// RemoveListener removes a listener.
-func (g *NetworkManager) RemoveListener(c <-chan validators.Validator) {
-	g.listenersMutex.Lock()
-	defer g.listenersMutex.Unlock()
-
-	index := -1
-	for i, l := range g.listeners {
-		if l == c {
-			index = i
-			break
-		}
+	process, ok := link.Meta.Data["process"].(string)
+	if !ok {
+		return nil, ErrMissingProcess
 	}
 
-	if index >= 0 {
-		close(g.listeners[index])
-		g.listeners[index] = g.listeners[len(g.listeners)-1]
-		g.listeners = g.listeners[:len(g.listeners)-1]
+	processesValidators := make(validators.ProcessesValidators, 0)
+	processRulesUpdate := func(process string, schema *RulesSchema, validators validators.Validators) {
+		m.store.UpdateValidator(ctx, process, schema)
+		processesValidators[process] = validators
 	}
+	if _, err = LoadProcessRules(&schema, process, m.validationCfg.PluginsPath, processRulesUpdate); err != nil {
+		return nil, err
+	}
+
+	return m.store.GetValidators(ctx)
 }
 
 // Current returns the current validator set
-func (g *NetworkManager) Current() validators.Validator {
-	return g.current
+func (m *NetworkManager) Current() validators.Validator {
+	return m.current
 }
 
-func (g *NetworkManager) updateCurrent(validatorsMap validators.ProcessesValidators) {
-	g.listenersMutex.RLock()
-	defer g.listenersMutex.RUnlock()
+func (m *NetworkManager) updateCurrent(validatorsMap validators.ProcessesValidators) {
+	m.current = validators.NewMultiValidator(validatorsMap)
+	m.broadcast(m.current)
+}
 
-	g.current = validators.NewMultiValidator(validatorsMap)
-
-	for _, listener := range g.listeners {
-		go func(listener chan validators.Validator) {
-			listener <- g.current
-		}(listener)
+func isGovernanceLink(link *cs.Link) bool {
+	if link.Meta.Process == GovernanceProcessName {
+		for _, tag := range link.Meta.Tags {
+			if tag == ValidatorTag {
+				return true
+			}
+		}
 	}
+	return false
 }

--- a/validation/networkmanager.go
+++ b/validation/networkmanager.go
@@ -1,0 +1,158 @@
+// Copyright 2017 Stratumn SAS. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validation
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+
+	"github.com/pkg/errors"
+	"github.com/stratumn/go-indigocore/cs"
+	"github.com/stratumn/go-indigocore/store"
+	"github.com/stratumn/go-indigocore/validation/validators"
+)
+
+// NetworkManager manages governance for validation rules management in an indigo network.
+type NetworkManager struct {
+	store *Store
+
+	validationCfg *Config
+	current       validators.Validator
+
+	networkListener <-chan *cs.Link
+	listenersMutex  sync.RWMutex
+	listeners       []chan validators.Validator
+}
+
+// NewNetworkManager returns a new NetworManager able to listen to the network and update governance rules.
+func NewNetworkManager(ctx context.Context, a store.Adapter, networkListener <-chan *cs.Link, validationCfg *Config) (Manager, error) {
+	var err error
+	var govMgr = NetworkManager{
+		store:           NewStore(a, validationCfg),
+		networkListener: networkListener,
+		validationCfg:   validationCfg,
+	}
+
+	currentValidators, err := govMgr.store.GetValidators(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not initialize network governor")
+	}
+	if len(currentValidators) > 0 {
+		govMgr.updateCurrent(currentValidators)
+	}
+
+	return &govMgr, nil
+}
+
+func isGovernanceLink(link *cs.Link) bool {
+	return true
+}
+
+// ListenAndUpdate will update the current validators whenever the provided rule file is updated.
+// This method must be run in a goroutine as it will wait for write events on the file.
+func (g *NetworkManager) ListenAndUpdate(ctx context.Context) error {
+	for {
+		select {
+		case link := <-g.networkListener:
+			if isGovernanceLink(link) {
+				if validators, err := g.GetValidators(ctx, link); err == nil {
+					g.updateCurrent(validators)
+				}
+			}
+
+		case <-ctx.Done():
+			g.listenersMutex.Lock()
+			defer g.listenersMutex.Unlock()
+			for _, s := range g.listeners {
+				close(s)
+			}
+			return ctx.Err()
+		}
+	}
+}
+
+// AddListener return a listener that will be notified when the validator changes.
+func (g *NetworkManager) AddListener() <-chan validators.Validator {
+	g.listenersMutex.Lock()
+	defer g.listenersMutex.Unlock()
+
+	subscribeChan := make(chan validators.Validator)
+	g.listeners = append(g.listeners, subscribeChan)
+
+	// Insert the current validator in the channel if there is one.
+	if g.current != nil {
+		go func() {
+			subscribeChan <- g.current
+		}()
+	}
+	return subscribeChan
+}
+
+// GetValidators extract the config from a link, parses it and returns as list of validators.
+func (g *NetworkManager) GetValidators(ctx context.Context, link *cs.Link) (processesValidators validators.ProcessesValidators, err error) {
+	jsonRules, err := json.Marshal(link.State)
+	if err != nil {
+		return nil, err
+	}
+
+	processRulesUpdate := func(process string, schema RulesSchema, validators validators.Validators) {
+		g.store.UpdateValidator(ctx, process, schema)
+		processesValidators[process] = validators
+	}
+	if _, err = LoadConfigContent(jsonRules, g.validationCfg.PluginsPath, processRulesUpdate); err != nil {
+		return nil, err
+	}
+
+	return processesValidators, nil
+}
+
+// RemoveListener removes a listener.
+func (g *NetworkManager) RemoveListener(c <-chan validators.Validator) {
+	g.listenersMutex.Lock()
+	defer g.listenersMutex.Unlock()
+
+	index := -1
+	for i, l := range g.listeners {
+		if l == c {
+			index = i
+			break
+		}
+	}
+
+	if index >= 0 {
+		close(g.listeners[index])
+		g.listeners[index] = g.listeners[len(g.listeners)-1]
+		g.listeners = g.listeners[:len(g.listeners)-1]
+	}
+}
+
+// Current returns the current validator set
+func (g *NetworkManager) Current() validators.Validator {
+	return g.current
+}
+
+func (g *NetworkManager) updateCurrent(validatorsMap validators.ProcessesValidators) {
+	g.listenersMutex.RLock()
+	defer g.listenersMutex.RUnlock()
+
+	g.current = validators.NewMultiValidator(validatorsMap)
+
+	for _, listener := range g.listeners {
+		go func(listener chan validators.Validator) {
+			listener <- g.current
+		}(listener)
+	}
+}

--- a/validation/networkmanager_test.go
+++ b/validation/networkmanager_test.go
@@ -1,0 +1,286 @@
+// Copyright 2017 Stratumn SAS. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validation_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stratumn/go-indigocore/cs/cstesting"
+
+	"github.com/stratumn/go-indigocore/cs"
+	"github.com/stratumn/go-indigocore/dummystore"
+	"github.com/stratumn/go-indigocore/store"
+	"github.com/stratumn/go-indigocore/store/storetesting"
+	"github.com/stratumn/go-indigocore/validation"
+	"github.com/stratumn/go-indigocore/validation/testutils"
+	"github.com/stratumn/go-indigocore/validation/validators"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNetworkManager(t *testing.T) {
+
+	auctionPKI, _ := testutils.LoadPKI([]byte(strings.Replace(testutils.ValidChatJSONPKIConfig, "Bob", "Dave", -1)))
+	auctionTypes, _ := testutils.LoadTypes([]byte(testutils.ValidChatJSONTypesConfig))
+
+	t.Run("New", func(t *testing.T) {
+		linkChan := make(chan *cs.Link)
+		t.Run("Manager without chan", func(t *testing.T) {
+			var v validators.Validator
+			a := new(storetesting.MockAdapter)
+			gov, err := validation.NewNetworkManager(context.Background(), a, nil, &validation.Config{})
+			assert.NoError(t, err)
+			assert.NotNil(t, gov)
+
+			v = gov.Current()
+			assert.Nil(t, v, "No validator loaded")
+		})
+
+		t.Run("Manager loads rules from store", func(t *testing.T) {
+			var v validators.Validator
+			a := dummystore.New(nil)
+			populateStoreWithValidData(t, a)
+			gov, err := validation.NewNetworkManager(context.Background(), a, linkChan, &validation.Config{
+				PluginsPath: pluginsPath,
+			})
+			assert.NoError(t, err, "Gouvernance is initialized by store")
+			require.NotNil(t, gov, "Gouvernance is initialized by store")
+
+			v = gov.Current()
+			assert.NotNil(t, v, "Validator loaded from store")
+		})
+
+		t.Run("Manager fails to load rules from store", func(t *testing.T) {
+			a := new(storetesting.MockAdapter)
+			a.MockFindSegments.Fn = func(filter *store.SegmentFilter) (cs.SegmentSlice, error) {
+				if len(filter.Tags) > 1 {
+					return cs.SegmentSlice{}, nil
+				}
+				link := cstesting.NewLinkBuilder().
+					WithProcess(validation.GovernanceProcessName).
+					WithTags(validation.ValidatorTag, "process").
+					Build()
+				return cs.SegmentSlice{link.Segmentify()}, nil
+			}
+
+			gov, err := validation.NewNetworkManager(context.Background(), a, linkChan, &validation.Config{})
+			assert.EqualError(t, err, "could not initialize network governor: could not find governance segments")
+			assert.Nil(t, gov)
+		})
+
+	})
+
+	t.Run("ListenAndUpdate", func(t *testing.T) {
+		linkChan := make(chan *cs.Link)
+
+		t.Run("Update rules in store when receiving new ones", func(t *testing.T) {
+			var v validators.Validator
+			linkChan := make(chan *cs.Link)
+			ctx := context.Background()
+			a := dummystore.New(nil)
+			populateStoreWithValidData(t, a)
+
+			gov, err := validation.NewNetworkManager(ctx, a, linkChan, &validation.Config{
+				PluginsPath: pluginsPath,
+			})
+			assert.NoError(t, err)
+			require.NotNil(t, gov)
+
+			waitValidator := gov.AddListener()
+			go func() {
+				assert.NoError(t, gov.ListenAndUpdate(ctx))
+			}()
+
+			v = <-waitValidator
+			assert.NotNil(t, v, "Validator loaded from store")
+
+			checkLastValidatorPriority(t, a, "chat", 0.)
+
+			go func() {
+				linkChan <- createGovernanceLink("chat", auctionPKI, auctionTypes)
+			}()
+
+			v = <-waitValidator
+			assert.NotNil(t, v, "Validator reloaded from file")
+
+			checkLastValidatorPriority(t, a, "chat", 1.)
+		})
+
+		t.Run("does not update rules if governance process name is missing", func(t *testing.T) {
+			ctx := context.Background()
+			a := dummystore.New(nil)
+			gov, err := validation.NewNetworkManager(ctx, a, linkChan, &validation.Config{})
+			assert.NoError(t, err)
+
+			waitValidator := gov.AddListener()
+			go func() {
+				assert.NoError(t, gov.ListenAndUpdate(ctx))
+			}()
+
+			go func() {
+				linkChan <- cstesting.NewLinkBuilder().
+					WithTags("process", validation.ValidatorTag).
+					WithState(map[string]interface{}{"pki": auctionPKI, "types": auctionTypes}).
+					WithMetadata(validation.ProcessMetaKey, "process").
+					Build()
+			}()
+
+			select {
+			case <-waitValidator:
+				t.Error("should not update validation rules")
+			case <-time.After(15 * time.Millisecond):
+				break
+			}
+			assert.Nil(t, gov.Current(), "Validator not loaded from file")
+		})
+
+		t.Run("does not update rules if validator tag is missing", func(t *testing.T) {
+			ctx := context.Background()
+			a := dummystore.New(nil)
+			gov, err := validation.NewNetworkManager(ctx, a, linkChan, &validation.Config{})
+			assert.NoError(t, err)
+
+			waitValidator := gov.AddListener()
+			go func() {
+				assert.NoError(t, gov.ListenAndUpdate(ctx))
+			}()
+
+			go func() {
+				linkChan <- cstesting.NewLinkBuilder().
+					WithProcess(validation.GovernanceProcessName).
+					WithTag("process").
+					WithState(map[string]interface{}{"pki": auctionPKI, "types": auctionTypes}).
+					WithMetadata(validation.ProcessMetaKey, "process").
+					Build()
+			}()
+
+			select {
+			case <-waitValidator:
+				t.Error("should not update validation rules")
+			case <-time.After(15 * time.Millisecond):
+				break
+			}
+			assert.Nil(t, gov.Current(), "Validator not loaded from file")
+		})
+
+		t.Run("does not update rules if process meta data is missing", func(t *testing.T) {
+			ctx := context.Background()
+			a := dummystore.New(nil)
+			gov, err := validation.NewNetworkManager(ctx, a, linkChan, &validation.Config{})
+			assert.NoError(t, err)
+
+			waitValidator := gov.AddListener()
+			go func() {
+				assert.NoError(t, gov.ListenAndUpdate(ctx))
+			}()
+
+			go func() {
+				linkChan <- cstesting.NewLinkBuilder().
+					WithProcess(validation.GovernanceProcessName).
+					WithTags("process", validation.ValidatorTag).
+					WithState(map[string]interface{}{"pki": auctionPKI, "types": auctionTypes}).
+					Build()
+			}()
+
+			select {
+			case <-waitValidator:
+				t.Error("should not update validation rules")
+			case <-time.After(15 * time.Millisecond):
+				break
+			}
+			assert.Nil(t, gov.Current(), "Validator not loaded from file")
+		})
+
+		t.Run("does not update rules if governance link is badly formatted", func(t *testing.T) {
+			ctx := context.Background()
+			a := dummystore.New(nil)
+			gov, err := validation.NewNetworkManager(ctx, a, linkChan, &validation.Config{})
+			assert.NoError(t, err)
+
+			waitValidator := gov.AddListener()
+			go func() {
+				assert.NoError(t, gov.ListenAndUpdate(ctx))
+			}()
+
+			go func() {
+				// PKI is missing
+				linkChan <- cstesting.NewLinkBuilder().
+					WithProcess(validation.GovernanceProcessName).
+					WithTags("process", validation.ValidatorTag).
+					WithState(map[string]interface{}{"types": auctionTypes}).
+					WithMetadata(validation.ProcessMetaKey, "process").
+					Build()
+			}()
+
+			select {
+			case <-waitValidator:
+				t.Error("should not update validation rules")
+			case <-time.After(15 * time.Millisecond):
+				break
+			}
+			assert.Nil(t, gov.Current(), "Validator not loaded from file")
+		})
+
+		t.Run("closes subscribing channels on context cancel", func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+
+			gov, err := validation.NewNetworkManager(ctx, dummystore.New(nil), linkChan, &validation.Config{})
+			require.NoError(t, err)
+
+			done := make(chan struct{})
+			go func() {
+				require.EqualError(t, gov.ListenAndUpdate(ctx), context.Canceled.Error())
+				done <- struct{}{}
+			}()
+			cancel()
+			<-done
+		})
+
+		t.Run("return an error when no network channel is set", func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			gov, err := validation.NewNetworkManager(ctx, dummystore.New(nil), nil, &validation.Config{})
+			require.NoError(t, err)
+			go func() {
+				assert.EqualError(t, gov.ListenAndUpdate(ctx), validation.ErrNoNetworkListener.Error())
+				cancel()
+			}()
+			<-ctx.Done()
+		})
+	})
+
+	t.Run("Current", func(t *testing.T) {
+		linkChan := make(chan *cs.Link)
+		t.Run("returns the current validator set", func(t *testing.T) {
+			ctx := context.Background()
+			gov, err := validation.NewNetworkManager(ctx, dummystore.New(nil), linkChan, &validation.Config{
+				PluginsPath: pluginsPath,
+			})
+			require.NoError(t, err)
+
+			go gov.ListenAndUpdate(ctx)
+			assert.Nil(t, gov.Current())
+
+			newValidator := gov.AddListener()
+			go func() {
+				linkChan <- createGovernanceLink("chat", auctionPKI, auctionTypes)
+			}()
+			v := <-newValidator
+			assert.Equal(t, v, gov.Current())
+		})
+	})
+}

--- a/validation/networkmanager_test.go
+++ b/validation/networkmanager_test.go
@@ -101,7 +101,7 @@ func TestNetworkManager(t *testing.T) {
 			assert.NoError(t, err)
 			require.NotNil(t, gov)
 
-			waitValidator := gov.AddListener()
+			waitValidator := gov.Subscribe()
 			go func() {
 				assert.NoError(t, gov.ListenAndUpdate(ctx))
 			}()
@@ -127,7 +127,7 @@ func TestNetworkManager(t *testing.T) {
 			gov, err := validation.NewNetworkManager(ctx, a, linkChan, &validation.Config{})
 			assert.NoError(t, err)
 
-			waitValidator := gov.AddListener()
+			waitValidator := gov.Subscribe()
 			go func() {
 				assert.NoError(t, gov.ListenAndUpdate(ctx))
 			}()
@@ -142,7 +142,7 @@ func TestNetworkManager(t *testing.T) {
 
 			select {
 			case <-waitValidator:
-				t.Error("should not update validation rules")
+				assert.Fail(t, "should not update validation rules")
 			case <-time.After(15 * time.Millisecond):
 				break
 			}
@@ -155,7 +155,7 @@ func TestNetworkManager(t *testing.T) {
 			gov, err := validation.NewNetworkManager(ctx, a, linkChan, &validation.Config{})
 			assert.NoError(t, err)
 
-			waitValidator := gov.AddListener()
+			waitValidator := gov.Subscribe()
 			go func() {
 				assert.NoError(t, gov.ListenAndUpdate(ctx))
 			}()
@@ -171,7 +171,7 @@ func TestNetworkManager(t *testing.T) {
 
 			select {
 			case <-waitValidator:
-				t.Error("should not update validation rules")
+				assert.Fail(t, "should not update validation rules")
 			case <-time.After(15 * time.Millisecond):
 				break
 			}
@@ -184,7 +184,7 @@ func TestNetworkManager(t *testing.T) {
 			gov, err := validation.NewNetworkManager(ctx, a, linkChan, &validation.Config{})
 			assert.NoError(t, err)
 
-			waitValidator := gov.AddListener()
+			waitValidator := gov.Subscribe()
 			go func() {
 				assert.NoError(t, gov.ListenAndUpdate(ctx))
 			}()
@@ -199,7 +199,7 @@ func TestNetworkManager(t *testing.T) {
 
 			select {
 			case <-waitValidator:
-				t.Error("should not update validation rules")
+				assert.Fail(t, "should not update validation rules")
 			case <-time.After(15 * time.Millisecond):
 				break
 			}
@@ -212,7 +212,7 @@ func TestNetworkManager(t *testing.T) {
 			gov, err := validation.NewNetworkManager(ctx, a, linkChan, &validation.Config{})
 			assert.NoError(t, err)
 
-			waitValidator := gov.AddListener()
+			waitValidator := gov.Subscribe()
 			go func() {
 				assert.NoError(t, gov.ListenAndUpdate(ctx))
 			}()
@@ -229,7 +229,7 @@ func TestNetworkManager(t *testing.T) {
 
 			select {
 			case <-waitValidator:
-				t.Error("should not update validation rules")
+				assert.Fail(t, "should not update validation rules")
 			case <-time.After(15 * time.Millisecond):
 				break
 			}
@@ -275,7 +275,7 @@ func TestNetworkManager(t *testing.T) {
 			go gov.ListenAndUpdate(ctx)
 			assert.Nil(t, gov.Current())
 
-			newValidator := gov.AddListener()
+			newValidator := gov.Subscribe()
 			go func() {
 				linkChan <- createGovernanceLink("chat", auctionPKI, auctionTypes)
 			}()

--- a/validation/store.go
+++ b/validation/store.go
@@ -33,6 +33,9 @@ const (
 	// GovernanceProcessName is the process name used for governance information storage.
 	GovernanceProcessName = "_governance"
 
+	// ProcessMetaKey is the key used to store the governed process name in the link's meta data.
+	ProcessMetaKey = "process"
+
 	// ValidatorTag is the tag used to find validators in storage.
 	ValidatorTag = "validators"
 )
@@ -136,22 +139,15 @@ func (s *Store) getProcessValidators(ctx context.Context, process string) (valid
 		return nil, ErrBadGovernanceSegment
 	}
 
-	processesValidators, err := LoadProcessRules(processesRules{
-		process: RulesSchema{
-			PKI:   &pki,
-			Types: types,
-		},
-	}, s.validationCfg.PluginsPath, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return processesValidators[process], nil
+	return LoadProcessRules(&RulesSchema{
+		PKI:   &pki,
+		Types: types,
+	}, process, s.validationCfg.PluginsPath, nil)
 }
 
 // UpdateValidator replaces the current validation rules in the store by the provided ones.
 // If none was found in the store, they will be created.
-func (s *Store) UpdateValidator(ctx context.Context, process string, schema RulesSchema) error {
+func (s *Store) UpdateValidator(ctx context.Context, process string, schema *RulesSchema) error {
 	segments, err := s.store.FindSegments(ctx, &store.SegmentFilter{
 		Pagination: defaultPagination,
 		Process:    GovernanceProcessName,
@@ -180,7 +176,7 @@ func (s *Store) UpdateValidator(ctx context.Context, process string, schema Rule
 	return nil
 }
 
-func (s *Store) uploadValidator(ctx context.Context, process string, schema RulesSchema, prevLink *cs.Link) error {
+func (s *Store) uploadValidator(ctx context.Context, process string, schema *RulesSchema, prevLink *cs.Link) error {
 	priority := 0.
 	mapID := ""
 	prevLinkHash := ""
@@ -205,6 +201,7 @@ func (s *Store) uploadValidator(ctx context.Context, process string, schema Rule
 		PrevLinkHash: prevLinkHash,
 		Priority:     priority,
 		Tags:         []string{process, ValidatorTag},
+		Data:         map[string]interface{}{ProcessMetaKey: process},
 	}
 
 	link := &cs.Link{

--- a/validation/store_test.go
+++ b/validation/store_test.go
@@ -130,7 +130,7 @@ func TestStore(t *testing.T) {
 			s := validation.NewStore(a, &validation.Config{})
 			err := s.UpdateValidator(ctx, process, validation.RulesSchema{
 				Types: auctionTypes,
-				PKI:   *auctionPKI,
+				PKI:   auctionPKI,
 			})
 			assert.EqualError(t, err, "Cannot retrieve governance segments: error")
 		})
@@ -143,13 +143,13 @@ func TestStore(t *testing.T) {
 			})
 			err := s.UpdateValidator(ctx, process, validation.RulesSchema{
 				Types: auctionTypes,
-				PKI:   *auctionPKI,
+				PKI:   auctionPKI,
 			})
 
 			validators, err := s.GetValidators(ctx)
 			assert.NoError(t, err)
 			require.Len(t, validators, 1)
-			assert.Len(t, validators[0], 6)
+			assert.Len(t, validators["auction"], 6)
 
 			segments, err := a.FindSegments(ctx, &store.SegmentFilter{
 				Pagination: store.Pagination{Limit: 1},
@@ -171,7 +171,7 @@ func TestStore(t *testing.T) {
 			s := validation.NewStore(a, &validation.Config{})
 			err := s.UpdateValidator(ctx, process, validation.RulesSchema{
 				Types: auctionTypes,
-				PKI:   *auctionPKI,
+				PKI:   auctionPKI,
 			})
 			assert.EqualError(t, err, "cannot create link for process governance auction: error")
 		})
@@ -188,7 +188,7 @@ func TestStore(t *testing.T) {
 
 			err := s.UpdateValidator(ctx, process, validation.RulesSchema{
 				Types: auctionTypes,
-				PKI:   *updatedAuctionPKI,
+				PKI:   updatedAuctionPKI,
 			})
 			require.NoError(t, err)
 
@@ -212,7 +212,7 @@ func TestStore(t *testing.T) {
 			s := validation.NewStore(a, &validation.Config{})
 			err := s.UpdateValidator(ctx, process, validation.RulesSchema{
 				Types: auctionTypes,
-				PKI:   *auctionPKI,
+				PKI:   auctionPKI,
 			})
 			assert.EqualError(t, err, "cannot create link for process governance auction: error")
 		})

--- a/validation/store_test.go
+++ b/validation/store_test.go
@@ -128,7 +128,7 @@ func TestStore(t *testing.T) {
 			a.MockFindSegments.Fn = func(*store.SegmentFilter) (cs.SegmentSlice, error) { return nil, errors.New("error") }
 
 			s := validation.NewStore(a, &validation.Config{})
-			err := s.UpdateValidator(ctx, process, validation.RulesSchema{
+			err := s.UpdateValidator(ctx, process, &validation.RulesSchema{
 				Types: auctionTypes,
 				PKI:   auctionPKI,
 			})
@@ -141,7 +141,7 @@ func TestStore(t *testing.T) {
 			s := validation.NewStore(a, &validation.Config{
 				PluginsPath: pluginsPath,
 			})
-			err := s.UpdateValidator(ctx, process, validation.RulesSchema{
+			err := s.UpdateValidator(ctx, process, &validation.RulesSchema{
 				Types: auctionTypes,
 				PKI:   auctionPKI,
 			})
@@ -169,7 +169,7 @@ func TestStore(t *testing.T) {
 			a.MockCreateLink.Fn = func(l *cs.Link) (*types.Bytes32, error) { return nil, errors.New("error") }
 
 			s := validation.NewStore(a, &validation.Config{})
-			err := s.UpdateValidator(ctx, process, validation.RulesSchema{
+			err := s.UpdateValidator(ctx, process, &validation.RulesSchema{
 				Types: auctionTypes,
 				PKI:   auctionPKI,
 			})
@@ -186,7 +186,7 @@ func TestStore(t *testing.T) {
 
 			updatedAuctionPKI, _ := testutils.LoadPKI([]byte(strings.Replace(testutils.ValidAuctionJSONPKIConfig, "alice", "jérome", -1)))
 
-			err := s.UpdateValidator(ctx, process, validation.RulesSchema{
+			err := s.UpdateValidator(ctx, process, &validation.RulesSchema{
 				Types: auctionTypes,
 				PKI:   updatedAuctionPKI,
 			})
@@ -210,7 +210,7 @@ func TestStore(t *testing.T) {
 			a.MockCreateLink.Fn = func(l *cs.Link) (*types.Bytes32, error) { return nil, errors.New("error") }
 
 			s := validation.NewStore(a, &validation.Config{})
-			err := s.UpdateValidator(ctx, process, validation.RulesSchema{
+			err := s.UpdateValidator(ctx, process, &validation.RulesSchema{
 				Types: auctionTypes,
 				PKI:   auctionPKI,
 			})
@@ -300,6 +300,7 @@ func createGovernanceLink(process string, pki *validators.PKI, types map[string]
 		WithProcess(validation.GovernanceProcessName).
 		WithTags(process, validation.ValidatorTag).
 		WithState(state).
+		WithMetadata(validation.ProcessMetaKey, process).
 		Build()
 	link.Meta.Priority = 0.
 	return link

--- a/validation/validation.go
+++ b/validation/validation.go
@@ -36,16 +36,11 @@ type Config struct {
 
 // Manager defines the methods to implement to manage validations in an indigo network.
 type Manager interface {
+	UpdateSubscriber
 
 	// ListenAndUpdate will update the current validators whenever a change occurs in the governance rules.
 	// This method must be run in a goroutine as it will wait for events from the network or file updates.
 	ListenAndUpdate(ctx context.Context) error
-
-	// AddListener adds a listener for validator changes.
-	AddListener() <-chan validators.Validator
-
-	// RemoveListener removes a listener.
-	RemoveListener(<-chan validators.Validator)
 
 	// Current returns the current version of the validator set.
 	Current() validators.Validator

--- a/validation/validators/multivalidator_test.go
+++ b/validation/validators/multivalidator_test.go
@@ -36,7 +36,7 @@ const validJSON = `
 `
 
 func TestMultiValidator_New(t *testing.T) {
-	mv := validators.NewMultiValidator(validators.Validators{})
+	mv := validators.NewMultiValidator(validators.ProcessesValidators{})
 	assert.NotNil(t, mv)
 }
 
@@ -84,19 +84,19 @@ func TestMultiValidator_Hash(t *testing.T) {
 
 		for _, tt := range testCases {
 			t.Run(tt.name, func(t *testing.T) {
-				mv1 := validators.NewMultiValidator(validators.Validators{tt.v1})
+				mv1 := validators.NewMultiValidator(validators.ProcessesValidators{"p": []validators.Validator{tt.v1}})
 
 				h1, err := mv1.Hash()
 				assert.NoError(t, err)
 				assert.NotNil(t, h1)
 
-				mv2 := validators.NewMultiValidator(validators.Validators{tt.v2})
+				mv2 := validators.NewMultiValidator(validators.ProcessesValidators{"p": []validators.Validator{tt.v2}})
 
 				h2, err := mv2.Hash()
 				assert.NoError(t, err)
 				assert.True(t, h1.Equals(h2))
 
-				mv3 := validators.NewMultiValidator(validators.Validators{tt.v3})
+				mv3 := validators.NewMultiValidator(validators.ProcessesValidators{"p": []validators.Validator{tt.v3}})
 
 				h3, err := mv3.Hash()
 				assert.NoError(t, err)
@@ -112,8 +112,8 @@ func TestMultiValidator_Hash(t *testing.T) {
 		pkiValidator := validators.NewPKIValidator(baseConfig, []string{"romeo"}, &validators.PKI{})
 		scriptValidator := &validators.ScriptValidator{Config: baseConfig, ScriptHash: *testutil.RandomHash()}
 
-		validatorList := validators.Validators{schemaValidator, transitionValidator, pkiValidator, scriptValidator}
-		mv := validators.NewMultiValidator(validatorList)
+		validatorList := []validators.Validator{schemaValidator, transitionValidator, pkiValidator, scriptValidator}
+		mv := validators.NewMultiValidator(validators.ProcessesValidators{"p": validatorList})
 		mvHash, err := mv.Hash()
 		assert.NoError(t, err)
 
@@ -158,7 +158,8 @@ func TestMultiValidator_Validate(t *testing.T) {
 	})
 	sigVCfg2 := validators.NewPKIValidator(baseConfig4, []string{}, &validators.PKI{})
 
-	mv := validators.NewMultiValidator(validators.Validators{svCfg1, svCfg2, sigVCfg1, sigVCfg2})
+	validatorList := []validators.Validator{svCfg1, svCfg2, sigVCfg1, sigVCfg2}
+	mv := validators.NewMultiValidator(validators.ProcessesValidators{"p": validatorList})
 
 	testState := map[string]interface{}{"message": "test"}
 

--- a/validation/validators/validator.go
+++ b/validation/validators/validator.go
@@ -40,3 +40,5 @@ type Validator interface {
 
 //Validators is an array of Validator.
 type Validators []Validator
+
+type ProcessesValidators map[string]Validators

--- a/validation/validators/validator.go
+++ b/validation/validators/validator.go
@@ -41,4 +41,5 @@ type Validator interface {
 //Validators is an array of Validator.
 type Validators []Validator
 
+//ProcessesValidators maps a process name to a list of validators.
 type ProcessesValidators map[string]Validators


### PR DESCRIPTION
In this PR: 
- small improvement on the validators side, the list of validators is now indexed by the process name (no need to call `ShouldValidate` on all validators on the multiValidator).
- a NetworkManager implementing the `validation.Manager` interface was added.
- the subscription mechansim of the Manager has been factorized and splitted in its own file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/go-indigocore/415)
<!-- Reviewable:end -->
