### PR TITLE
validation: fix validation store update

### DIFF
--- a/cs/cstesting/builder.go
+++ b/cs/cstesting/builder.go
@@ -88,6 +88,12 @@ func (lb *LinkBuilder) WithProcess(process string) *LinkBuilder {
 	return lb
 }
 
+// WithPriority fills the link's priority.
+func (lb *LinkBuilder) WithPriority(priority float64) *LinkBuilder {
+	lb.Link.Meta.Priority = priority
+	return lb
+}
+
 // WithType fills the link's type.
 func (lb *LinkBuilder) WithType(linkType string) *LinkBuilder {
 	lb.Link.Meta.Type = linkType

--- a/validation/localmanager.go
+++ b/validation/localmanager.go
@@ -102,10 +102,9 @@ func (m *LocalManager) Current() validators.Validator {
 func (m *LocalManager) GetValidators(ctx context.Context) (validators.ProcessesValidators, error) {
 	processesValidators := make(validators.ProcessesValidators, 0)
 
-	var loadConfigErr error
 	var updateStoreErr error
 	if m.validationCfg.RulesPath != "" {
-		_, loadConfigErr = LoadConfig(m.validationCfg, func(process string, schema *RulesSchema, validators validators.Validators) {
+		_, loadConfigErr := LoadConfig(m.validationCfg, func(process string, schema *RulesSchema, validators validators.Validators) {
 			newValidatorLink, err := m.store.LinkFromSchema(ctx, process, schema)
 			if err != nil {
 				log.Error("Could not create link from validation rules", err)

--- a/validation/localmanager.go
+++ b/validation/localmanager.go
@@ -100,20 +100,32 @@ func (m *LocalManager) Current() validators.Validator {
 // GetValidators returns the list of validators for each process by parsing a local file.
 // The validators are updated in the store according to local changes.
 func (m *LocalManager) GetValidators(ctx context.Context) (validators.ProcessesValidators, error) {
-	var err error
 	processesValidators := make(validators.ProcessesValidators, 0)
 
+	var loadConfigErr error
+	var updateStoreErr error
 	if m.validationCfg.RulesPath != "" {
-		_, err = LoadConfig(m.validationCfg, func(process string, schema *RulesSchema, validators validators.Validators) {
-			m.store.UpdateValidator(ctx, process, schema)
+		_, loadConfigErr = LoadConfig(m.validationCfg, func(process string, schema *RulesSchema, validators validators.Validators) {
+			newValidatorLink, err := m.store.LinkFromSchema(ctx, process, schema)
+			if err != nil {
+				log.Error("Could not create link from validation rules", err)
+				return
+			}
+			updateStoreErr = m.store.UpdateValidator(ctx, newValidatorLink)
+			if updateStoreErr != nil {
+				log.Errorf("Could not update validation rules in store for process %s: %s", process, updateStoreErr)
+				return
+			}
 			processesValidators[process] = validators
 		})
-		if err != nil {
-			return nil, errors.Wrapf(err, "Cannot load validator rules file %s", m.validationCfg.RulesPath)
-
+		if loadConfigErr != nil {
+			return nil, errors.Wrapf(loadConfigErr, "Cannot load validator rules file %s", m.validationCfg.RulesPath)
+		}
+		if updateStoreErr != nil {
+			return nil, updateStoreErr
 		}
 	}
-	return processesValidators, err
+	return processesValidators, nil
 }
 
 func (m *LocalManager) updateCurrent(validatorsMap validators.ProcessesValidators) {

--- a/validation/localmanager_test.go
+++ b/validation/localmanager_test.go
@@ -101,7 +101,8 @@ func TestLocalManager(t *testing.T) {
 			var v validators.Validator
 			a := dummystore.New(nil)
 			populateStoreWithValidData(t, a)
-			checkLastValidatorPriority(t, a, "auction", 1.)
+			l := getLastValidator(t, a, "auction")
+			assert.Equal(t, 1., l.Meta.Priority)
 			testFile := utils.CreateTempFile(t, testutils.ValidJSONConfig)
 			defer os.Remove(testFile)
 			gov, err := validation.NewLocalManager(context.Background(), a, &validation.Config{
@@ -113,7 +114,8 @@ func TestLocalManager(t *testing.T) {
 
 			v = gov.Current()
 			assert.NotNil(t, v, "Validator loaded from file")
-			checkLastValidatorPriority(t, a, "auction", 2.)
+			l = getLastValidator(t, a, "auction")
+			assert.Equal(t, 2., l.Meta.Priority)
 		})
 	})
 
@@ -134,7 +136,8 @@ func TestLocalManager(t *testing.T) {
 			v = <-waitValidator
 			assert.NotNil(t, v, "Validator loaded from file")
 
-			checkLastValidatorPriority(t, a, "chat", 0.)
+			l := getLastValidator(t, a, "chat")
+			assert.Equal(t, 0., l.Meta.Priority)
 
 			chatJSON := testutils.CreateValidatorJSON("chat",
 				strings.Replace(testutils.ValidChatJSONPKIConfig, "Bob", "Dave", -1),
@@ -151,7 +154,8 @@ func TestLocalManager(t *testing.T) {
 			v = <-waitValidator
 			assert.NotNil(t, v, "Validator reloaded from file")
 
-			checkLastValidatorPriority(t, a, "chat", 1.)
+			l = getLastValidator(t, a, "chat")
+			assert.Equal(t, 1., l.Meta.Priority)
 		})
 
 		t.Run("closes subscribing channels on context cancel", func(t *testing.T) {

--- a/validation/networkmanager_test.go
+++ b/validation/networkmanager_test.go
@@ -109,16 +109,29 @@ func TestNetworkManager(t *testing.T) {
 			v = <-waitValidator
 			assert.NotNil(t, v, "Validator loaded from store")
 
-			checkLastValidatorPriority(t, a, "chat", 0.)
+			l := getLastValidator(t, a, "chat")
+			assert.Equal(t, 0., l.Meta.Priority)
 
 			go func() {
-				linkChan <- createGovernanceLink("chat", auctionPKI, auctionTypes)
+				parent := getLastValidator(t, a, "chat")
+				parentHash, _ := parent.HashString()
+				new := cstesting.NewLinkBuilder().
+					WithMapID(parent.Meta.MapID).
+					WithPrevLinkHash(parentHash).
+					WithProcess(validation.GovernanceProcessName).
+					WithTags(validation.ValidatorTag, "chat").
+					WithMetadata(validation.ProcessMetaKey, "chat").
+					WithPriority(1.).
+					WithState(map[string]interface{}{"pki": auctionPKI, "types": auctionTypes}).
+					Build()
+				linkChan <- new
 			}()
 
 			v = <-waitValidator
 			assert.NotNil(t, v, "Validator reloaded from file")
 
-			checkLastValidatorPriority(t, a, "chat", 1.)
+			l = getLastValidator(t, a, "chat")
+			assert.Equal(t, 1., l.Meta.Priority)
 		})
 
 		t.Run("does not update rules if governance process name is missing", func(t *testing.T) {
@@ -267,7 +280,8 @@ func TestNetworkManager(t *testing.T) {
 		linkChan := make(chan *cs.Link)
 		t.Run("returns the current validator set", func(t *testing.T) {
 			ctx := context.Background()
-			gov, err := validation.NewNetworkManager(ctx, dummystore.New(nil), linkChan, &validation.Config{
+			a := dummystore.New(nil)
+			gov, err := validation.NewNetworkManager(ctx, a, linkChan, &validation.Config{
 				PluginsPath: pluginsPath,
 			})
 			require.NoError(t, err)
@@ -277,7 +291,15 @@ func TestNetworkManager(t *testing.T) {
 
 			newValidator := gov.Subscribe()
 			go func() {
-				linkChan <- createGovernanceLink("chat", auctionPKI, auctionTypes)
+				new := cstesting.NewLinkBuilder().
+					WithProcess(validation.GovernanceProcessName).
+					WithTags(validation.ValidatorTag, "chat").
+					WithPrevLinkHash("").
+					WithMetadata(validation.ProcessMetaKey, "chat").
+					WithPriority(0.).
+					WithState(map[string]interface{}{"pki": auctionPKI, "types": auctionTypes}).
+					Build()
+				linkChan <- new
 			}()
 			v := <-newValidator
 			assert.Equal(t, v, gov.Current())

--- a/validation/networkmanager_test.go
+++ b/validation/networkmanager_test.go
@@ -115,7 +115,7 @@ func TestNetworkManager(t *testing.T) {
 			go func() {
 				parent := getLastValidator(t, a, "chat")
 				parentHash, _ := parent.HashString()
-				new := cstesting.NewLinkBuilder().
+				newRules := cstesting.NewLinkBuilder().
 					WithMapID(parent.Meta.MapID).
 					WithPrevLinkHash(parentHash).
 					WithProcess(validation.GovernanceProcessName).
@@ -124,7 +124,7 @@ func TestNetworkManager(t *testing.T) {
 					WithPriority(1.).
 					WithState(map[string]interface{}{"pki": auctionPKI, "types": auctionTypes}).
 					Build()
-				linkChan <- new
+				linkChan <- newRules
 			}()
 
 			v = <-waitValidator
@@ -291,7 +291,7 @@ func TestNetworkManager(t *testing.T) {
 
 			newValidator := gov.Subscribe()
 			go func() {
-				new := cstesting.NewLinkBuilder().
+				newRules := cstesting.NewLinkBuilder().
 					WithProcess(validation.GovernanceProcessName).
 					WithTags(validation.ValidatorTag, "chat").
 					WithPrevLinkHash("").
@@ -299,7 +299,7 @@ func TestNetworkManager(t *testing.T) {
 					WithPriority(0.).
 					WithState(map[string]interface{}{"pki": auctionPKI, "types": auctionTypes}).
 					Build()
-				linkChan <- new
+				linkChan <- newRules
 			}()
 			v := <-newValidator
 			assert.Equal(t, v, gov.Current())

--- a/validation/store.go
+++ b/validation/store.go
@@ -50,6 +50,18 @@ var (
 	// ErrBadGovernanceSegment is the error returned when the governance segment has a bad format
 	ErrBadGovernanceSegment = errors.New("governance segment is badly formatted")
 
+	// ErrBadPriority is returned when the new governance link's priority is less than or equal to the previous governance link's priority.
+	ErrBadPriority = errors.New("priority has to be higher than previous governance link")
+
+	// ErrBadPrevLinkHash is returned when the new governance link's prevLInkHash is different from the previous governance link's hash.
+	ErrBadPrevLinkHash = errors.New("prevLinkHash does not match previous governance link")
+
+	// ErrBadMapID is returned when the governance link's mapID does not match the previous link's mapID.
+	ErrBadMapID = errors.New("governance rules for a single process must belong to the same map")
+
+	// ErrBadProcess is returned when the governance link's process does not match the previous link's process.
+	ErrBadProcess = errors.New("process does not match the previous governance link")
+
 	defaultPagination = store.Pagination{
 		Offset: 0,
 		Limit:  1,
@@ -146,8 +158,13 @@ func (s *Store) getProcessValidators(ctx context.Context, process string) (valid
 }
 
 // UpdateValidator replaces the current validation rules in the store by the provided ones.
-// If none was found in the store, they will be created.
-func (s *Store) UpdateValidator(ctx context.Context, process string, schema *RulesSchema) error {
+// It checks that the provided link correcly references the previous rules' link.
+func (s *Store) UpdateValidator(ctx context.Context, link *cs.Link) error {
+	process, ok := link.Meta.Data[ProcessMetaKey].(string)
+	if !ok {
+		return ErrMissingProcess
+	}
+
 	segments, err := s.store.FindSegments(ctx, &store.SegmentFilter{
 		Pagination: defaultPagination,
 		Process:    GovernanceProcessName,
@@ -156,36 +173,72 @@ func (s *Store) UpdateValidator(ctx context.Context, process string, schema *Rul
 	if err != nil {
 		return errors.Wrap(errors.WithStack(err), "Cannot retrieve governance segments")
 	}
+
 	if len(segments) == 0 {
-		log.Warnf("No governance segments found for process %s", process)
-		if err = s.uploadValidator(ctx, process, schema, nil); err != nil {
-			return errors.Wrap(err, "Cannot upload validator")
+		log.Infof("No governance segments found for process %s, creating validator", process)
+		if link.Meta.Priority != 0. {
+			return ErrBadPriority
 		}
-		return nil
-	}
-	link := segments[0].Link
-	if canonicalCompare(link.State["pki"], schema.PKI) != nil ||
-		canonicalCompare(link.State["types"], schema.Types) != nil {
-		log.Infof("Validator or process %s has to be updated in store", process)
-		if err = s.uploadValidator(ctx, process, schema, &link); err != nil {
-			log.Warnf("Cannot upload validator: %s", err)
-			return err
+		if link.Meta.PrevLinkHash != "" {
+			return ErrBadPrevLinkHash
 		}
+		return s.uploadValidator(ctx, link)
 	}
 
+	lastGovernanceLink := segments[0].Link
+	if canonicalCompare(link.State, lastGovernanceLink.State) != nil {
+		log.Infof("Validator of process %s has to be updated in store", process)
+		if link.Meta.Priority <= lastGovernanceLink.Meta.Priority {
+			return ErrBadPriority
+		}
+		lastGovernanceLinkHash, _ := lastGovernanceLink.HashString()
+		if link.Meta.PrevLinkHash != lastGovernanceLinkHash {
+			return ErrBadPrevLinkHash
+		}
+		if link.Meta.MapID != lastGovernanceLink.Meta.MapID {
+			return ErrBadMapID
+		}
+		if process != lastGovernanceLink.Meta.Data[ProcessMetaKey] {
+			return ErrBadProcess
+		}
+		return s.uploadValidator(ctx, link)
+	}
 	return nil
 }
 
-func (s *Store) uploadValidator(ctx context.Context, process string, schema *RulesSchema, prevLink *cs.Link) error {
+func (s *Store) uploadValidator(ctx context.Context, link *cs.Link) error {
+	hash, err := s.store.CreateLink(ctx, link)
+	if err != nil {
+		return errors.Wrapf(err, "cannot create link for process governance %s", link.Meta.Data[ProcessMetaKey])
+	}
+	log.Infof("New validator rules store for process %s: %q", link.Meta.Data[ProcessMetaKey], hash)
+	return nil
+}
+
+// LinkFromSchema creates a chainscript link from a PKI and a set of rules.
+// It first tries to fetch the previous governance link for this process and builds the new one on top of it.
+// If no previous governance link exists, a link from a new map is created.
+func (s *Store) LinkFromSchema(ctx context.Context, process string, schema *RulesSchema) (*cs.Link, error) {
+	var lastGovernanceLink cs.Link
+	segments, err := s.store.FindSegments(ctx, &store.SegmentFilter{
+		Pagination: defaultPagination,
+		Process:    GovernanceProcessName,
+		Tags:       []string{process, ValidatorTag},
+	})
+	if err != nil {
+		return nil, errors.Wrap(errors.WithStack(err), "Cannot retrieve governance segments")
+	}
+
 	priority := 0.
 	mapID := ""
 	prevLinkHash := ""
-	if prevLink != nil {
-		priority = prevLink.Meta.Priority + 1.
-		mapID = prevLink.Meta.MapID
+	if len(segments) > 0 {
+		lastGovernanceLink = segments[0].Link
+		priority = lastGovernanceLink.Meta.Priority + 1.
+		mapID = lastGovernanceLink.Meta.MapID
 		var err error
-		if prevLinkHash, err = prevLink.HashString(); err != nil {
-			return errors.Wrapf(err, "cannot get previous hash for process governance %s", process)
+		if prevLinkHash, err = lastGovernanceLink.HashString(); err != nil {
+			return nil, errors.Wrapf(err, "cannot get previous hash for process governance %s", process)
 		}
 	} else {
 		mapID = uuid.NewV4().String()
@@ -204,18 +257,11 @@ func (s *Store) uploadValidator(ctx context.Context, process string, schema *Rul
 		Data:         map[string]interface{}{ProcessMetaKey: process},
 	}
 
-	link := &cs.Link{
+	return &cs.Link{
 		State:      linkState,
 		Meta:       linkMeta,
 		Signatures: cs.Signatures{},
-	}
-
-	hash, err := s.store.CreateLink(ctx, link)
-	if err != nil {
-		return errors.Wrapf(err, "cannot create link for process governance %s", process)
-	}
-	log.Infof("New validator rules store for process %s: %q", process, hash)
-	return nil
+	}, nil
 }
 
 func canonicalCompare(metaData interface{}, fileData interface{}) error {

--- a/validation/store.go
+++ b/validation/store.go
@@ -176,9 +176,6 @@ func (s *Store) UpdateValidator(ctx context.Context, link *cs.Link) error {
 
 	if len(segments) == 0 {
 		log.Infof("No governance segments found for process %s, creating validator", process)
-		if link.Meta.Priority != 0. {
-			return ErrBadPriority
-		}
 		if link.Meta.PrevLinkHash != "" {
 			return ErrBadPrevLinkHash
 		}


### PR DESCRIPTION
I realised I made a bad design choice by letting the validation store create a new governance link by itself : 
- first and foremost : a store creating a link doesn't make any sense.
- we need to keep the signatures attached to the governance links provided by the network, otherwise they won't be valid anymore ! (obviously -_-).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/go-indigocore/416)
<!-- Reviewable:end -->
