### PR TITLE
cs: link.state is now an interface{}

### DIFF
--- a/agent/agenttestcases/createsegment.go
+++ b/agent/agenttestcases/createsegment.go
@@ -33,7 +33,7 @@ func (f Factory) TestCreateSegmentOK(t *testing.T) {
 	segment, err := f.Client.CreateSegment(process, parent.GetLinkHash(), action, nil, "test")
 	assert.NoError(t, err)
 	assert.NotNil(t, segment)
-	assert.Equal(t, "test", segment.Link.State["title"])
+	assert.EqualValues(t, map[string]interface{}{"title": "test"}, segment.Link.State.Data)
 }
 
 // TestCreateSegmentWithRefs tests the client's ability to handle a CreateSegment request

--- a/agent/agenttestcases/createsegment.go
+++ b/agent/agenttestcases/createsegment.go
@@ -33,7 +33,8 @@ func (f Factory) TestCreateSegmentOK(t *testing.T) {
 	segment, err := f.Client.CreateSegment(process, parent.GetLinkHash(), action, nil, "test")
 	assert.NoError(t, err)
 	assert.NotNil(t, segment)
-	assert.EqualValues(t, map[string]interface{}{"title": "test"}, segment.Link.State.Data)
+	title, _ := segment.Link.State.Get("title")
+	assert.EqualValues(t, "test", title)
 }
 
 // TestCreateSegmentWithRefs tests the client's ability to handle a CreateSegment request

--- a/agent/client/utils_test.go
+++ b/agent/client/utils_test.go
@@ -138,8 +138,10 @@ func (m *mockHTTPServer) mockCreateSegment(w http.ResponseWriter, r *http.Reques
 
 	s := cs.Segment{
 		Link: cs.Link{
-			State: map[string]interface{}{
-				"title": arg,
+			State: cs.LinkState{
+				Data: map[string]interface{}{
+					"title": arg,
+				},
 			},
 			Meta: cs.LinkMeta{
 				MapID: "mapId",
@@ -194,8 +196,10 @@ func (m *mockHTTPServer) mockCreateMap(w http.ResponseWriter, r *http.Request) {
 	}
 	s := cs.Segment{
 		Link: cs.Link{
-			State: map[string]interface{}{
-				"title": arg,
+			State: cs.LinkState{
+				Data: map[string]interface{}{
+					"title": arg,
+				},
 			},
 			Meta: cs.LinkMeta{
 				MapID: "mapId",

--- a/cs/cs.go
+++ b/cs/cs.go
@@ -143,23 +143,24 @@ type LinkMeta struct {
 	Data         map[string]interface{} `json:"data"`
 }
 
-// LinkState contains aribitrary data.
+// LinkState contains arbitrary data.
 // It implements json.Marshaler and json.Unmarshaler.
 type LinkState struct {
 	Data interface{}
 }
 
-// Structurize transforms the state into the provided type.
-// This is useful to turn a map[string]interface{} into a custom type.
-func (ls *LinkState) Structurize(structuredState interface{}) error {
+// Structurize transforms the state into a custom type.
+// The provided argument should be a pointer to struct (passing a literal type will fail).
+// On success, 'stateType' overriden with the state's data matching its JSON structure.
+func (ls *LinkState) Structurize(stateType interface{}) error {
 	stateBytes, err := json.Marshal(ls.Data)
 	if err != nil {
 		return err
 	}
-	if err := json.Unmarshal(stateBytes, structuredState); err != nil {
+	if err := json.Unmarshal(stateBytes, stateType); err != nil {
 		return err
 	}
-	ls.Data = structuredState
+	ls.Data = stateType
 	return nil
 }
 

--- a/cs/cs_test.go
+++ b/cs/cs_test.go
@@ -117,7 +117,7 @@ func TestLinkState(t *testing.T) {
 		assert.Error(t, err)
 	})
 
-	t.Run("Structuralize", func(t *testing.T) {
+	t.Run("Structurize", func(t *testing.T) {
 		t.Run("transforms into custom type", func(t *testing.T) {
 			state := cs.LinkState{
 				Data: map[string]interface{}{

--- a/cs/cs_test.go
+++ b/cs/cs_test.go
@@ -140,6 +140,60 @@ func TestLinkState(t *testing.T) {
 			assert.Error(t, err)
 		})
 	})
+
+	t.Run("Get", func(t *testing.T) {
+		t.Run("retrieves a value from the state", func(t *testing.T) {
+			state := cs.LinkState{
+				Data: map[string]interface{}{
+					"test": "jean-pierre",
+				},
+			}
+			val, err := state.Get("test")
+			assert.NoError(t, err)
+			assert.Equal(t, "jean-pierre", val)
+		})
+
+		t.Run("returns nil when the key does not exist", func(t *testing.T) {
+			state := cs.LinkState{
+				Data: map[string]interface{}{
+					"test": "jean-pierre",
+				},
+			}
+			val, err := state.Get("none")
+			assert.NoError(t, err)
+			assert.Nil(t, val)
+		})
+
+		t.Run("fails when the state is not a map", func(t *testing.T) {
+			state := cs.LinkState{
+				Data: "test",
+			}
+			_, err := state.Get("test")
+			assert.EqualError(t, err, cs.ErrBadStateType.Error())
+		})
+	})
+
+	t.Run("Set", func(t *testing.T) {
+		t.Run("sets the value in the state ", func(t *testing.T) {
+			state := cs.LinkState{
+				Data: map[string]interface{}{},
+			}
+			err := state.Set("key", "value")
+			assert.NoError(t, err)
+
+			val, err := state.Get("key")
+			assert.NoError(t, err)
+			assert.Equal(t, "value", val)
+		})
+
+		t.Run("fails when the state is not a map", func(t *testing.T) {
+			state := cs.LinkState{
+				Data: "test",
+			}
+			err := state.Set("key", "value")
+			assert.EqualError(t, err, cs.ErrBadStateType.Error())
+		})
+	})
 }
 
 func TestLinkValidate_processEmpty(t *testing.T) {

--- a/cs/cstesting/builder.go
+++ b/cs/cstesting/builder.go
@@ -40,8 +40,8 @@ func (lb *LinkBuilder) Invalid() *LinkBuilder {
 }
 
 // WithState fills the link's state.
-func (lb *LinkBuilder) WithState(state map[string]interface{}) *LinkBuilder {
-	lb.Link.State = state
+func (lb *LinkBuilder) WithState(state interface{}) *LinkBuilder {
+	lb.Link.State.Data = state
 	return lb
 }
 

--- a/cs/cstesting/cstesting.go
+++ b/cs/cstesting/cstesting.go
@@ -79,9 +79,11 @@ func RandomEvidence() *cs.Evidence {
 }
 
 // ChangeState clones a link and randomly changes its state.
+// It assumes the state is a map[string]inteface{}.
 func ChangeState(l *cs.Link) *cs.Link {
 	clone := Clone(l)
-	clone.State.Data = map[string]interface{}{"random": testutil.RandomString(12)}
+	// We assume that the link's state is already a map, so we ignore the error.
+	_ = clone.State.Set("random", testutil.RandomString(12))
 	return clone
 }
 

--- a/cs/cstesting/cstesting.go
+++ b/cs/cstesting/cstesting.go
@@ -47,8 +47,10 @@ func createLink(process, linkType, mapID, prevLinkHash string, tags []string, pr
 	}
 
 	link := &cs.Link{
-		State: map[string]interface{}{
-			"random": testutil.RandomString(12),
+		State: cs.LinkState{
+			Data: map[string]interface{}{
+				"random": testutil.RandomString(12),
+			},
 		},
 		Meta:       linkMeta,
 		Signatures: cs.Signatures{},
@@ -79,7 +81,7 @@ func RandomEvidence() *cs.Evidence {
 // ChangeState clones a link and randomly changes its state.
 func ChangeState(l *cs.Link) *cs.Link {
 	clone := Clone(l)
-	clone.State["random"] = testutil.RandomString(12)
+	clone.State.Data = map[string]interface{}{"random": testutil.RandomString(12)}
 	return clone
 }
 

--- a/cs/signature_test.go
+++ b/cs/signature_test.go
@@ -77,7 +77,7 @@ func TestNewSignature(t *testing.T) {
 		payloadPath := "[state,meta]"
 		link.State.Data = func() {}
 		_, err := cs.NewSignature(payloadPath, privPEM, link)
-		assert.EqualError(t, err, "canonicaljson: error calling MarshalJSON for type cs.LinkState: json: unsupported type: func()")
+		assert.Error(t, err)
 	})
 
 }

--- a/cs/signature_test.go
+++ b/cs/signature_test.go
@@ -75,9 +75,9 @@ func TestNewSignature(t *testing.T) {
 
 	t.Run("Canonicaljson failed", func(t *testing.T) {
 		payloadPath := "[state,meta]"
-		link.State["lol"] = func() {}
+		link.State.Data = func() {}
 		_, err := cs.NewSignature(payloadPath, privPEM, link)
-		assert.EqualError(t, err, "canonicaljson: unsupported type: func()")
+		assert.EqualError(t, err, "canonicaljson: error calling MarshalJSON for type cs.LinkState: json: unsupported type: func()")
 	})
 
 }

--- a/cs/signature_test.go
+++ b/cs/signature_test.go
@@ -75,7 +75,7 @@ func TestNewSignature(t *testing.T) {
 
 	t.Run("Canonicaljson failed", func(t *testing.T) {
 		payloadPath := "[state,meta]"
-		link.State.Data = func() {}
+		link.State.Set("test", func() {})
 		_, err := cs.NewSignature(payloadPath, privPEM, link)
 		assert.Error(t, err)
 	})

--- a/cs/signature_test.go
+++ b/cs/signature_test.go
@@ -75,7 +75,7 @@ func TestNewSignature(t *testing.T) {
 
 	t.Run("Canonicaljson failed", func(t *testing.T) {
 		payloadPath := "[state,meta]"
-		link.State.Set("test", func() {})
+		_ = link.State.Set("test", func() {})
 		_, err := cs.NewSignature(payloadPath, privPEM, link)
 		assert.Error(t, err)
 	})

--- a/elasticsearchstore/api.go
+++ b/elasticsearchstore/api.go
@@ -243,7 +243,7 @@ func fromLink(link *cs.Link) (*linkDoc, error) {
 		StateTokens: []string{},
 	}
 
-	doc.extractTokens(link.State)
+	doc.extractTokens(link.State.Data)
 
 	return &doc, nil
 }

--- a/elasticsearchstore/elasticsearchstore_test.go
+++ b/elasticsearchstore/elasticsearchstore_test.go
@@ -259,7 +259,7 @@ func TestElasticSearchStoreSearch(t *testing.T) {
 				"num": 23
 			}
 		}`)
-		l.State = map[string]interface{}{}
+		l.State.Data = map[string]interface{}{}
 		json.Unmarshal(state, &l.State)
 
 		expectedTokens := []string{"hello", "abc", "james", "def", "world"}

--- a/elasticsearchstore/elasticsearchstore_test.go
+++ b/elasticsearchstore/elasticsearchstore_test.go
@@ -259,7 +259,6 @@ func TestElasticSearchStoreSearch(t *testing.T) {
 				"num": 23
 			}
 		}`)
-		l.State.Data = map[string]interface{}{}
 		json.Unmarshal(state, &l.State)
 
 		expectedTokens := []string{"hello", "abc", "james", "def", "world"}

--- a/validation/validators/validator_test.go
+++ b/validation/validators/validator_test.go
@@ -90,9 +90,11 @@ func initTestCases(t *testing.T) (store.Adapter, []testCase) {
 	}, {
 		name: "valid-link",
 		link: &cs.Link{
-			State: map[string]interface{}{
-				"buyer":    "alice",
-				"bidPrice": 42,
+			State: cs.LinkState{
+				Data: map[string]interface{}{
+					"buyer":    "alice",
+					"bidPrice": 42,
+				},
 			},
 			Meta: cs.LinkMeta{
 				Process:      "auction",
@@ -113,8 +115,10 @@ func initTestCases(t *testing.T) (store.Adapter, []testCase) {
 	}, {
 		name: "missing-required-field",
 		link: &cs.Link{
-			State: map[string]interface{}{
-				"to": "bob",
+			State: cs.LinkState{
+				Data: map[string]interface{}{
+					"to": "bob",
+				},
 			},
 			Meta: cs.LinkMeta{
 				Process: "chat",
@@ -125,9 +129,11 @@ func initTestCases(t *testing.T) (store.Adapter, []testCase) {
 	}, {
 		name: "invalid-field-value",
 		link: &cs.Link{
-			State: map[string]interface{}{
-				"buyer":    "alice",
-				"bidPrice": -10,
+			State: cs.LinkState{
+				Data: map[string]interface{}{
+					"buyer":    "alice",
+					"bidPrice": -10,
+				},
 			},
 			Meta: cs.LinkMeta{
 				Process: "auction",


### PR DESCRIPTION
This PR changes the type of link.state from map[string]interface{} to a custom type (cs.LinkState) which wraps an interface{}.
It is useful to have a custom type of an interface{}  directly because there is a cool helper function that turns a json structure (map[string]interface{}) into a custom type. The type also impelments json.(Un)Marshaler to avoid having a "data" key in the data structure.

As any change to chainscript can possibly cause issues elsewhere, don't hesitate to tell me if you can think of anything else I would have missed !

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/go-indigocore/423)
<!-- Reviewable:end -->
