### PR TITLE
cs: serialize link state to json before signing

### DIFF
--- a/cs/cs.go
+++ b/cs/cs.go
@@ -18,6 +18,7 @@ package cs
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/json"
 	"reflect"
 
 	cj "github.com/gibson042/canonicaljson-go"
@@ -268,6 +269,33 @@ func (l Link) Segmentify() *Segment {
 			LinkHash: linkHash,
 		},
 	}
+}
+
+// Clone returns a copy of the link.
+// Since it uses the json Marshaler, the state is automatically
+// converted to a map[string]interface if it is a custom struct.
+func (l *Link) Clone() (*Link, error) {
+	var clone Link
+	js, err := json.Marshal(l)
+	if err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(js, &clone); err != nil {
+		return nil, err
+	}
+
+	return &clone, nil
+}
+
+// Search executes a JMESPATH query on the link and return the matching payload.
+func (l *Link) Search(jsonQuery string) (interface{}, error) {
+	// Cloning the link allows the state to be serialized to
+	// JSON which is needed for the jmespath query.
+	cloned, err := l.Clone()
+	if err != nil {
+		return nil, err
+	}
+	return jmespath.Search(jsonQuery, cloned)
 }
 
 // SegmentSlice is a slice of segment pointers.

--- a/cs/cstesting/builder.go
+++ b/cs/cstesting/builder.go
@@ -155,7 +155,7 @@ func (lb *LinkBuilder) SignWithKeyAndPath(priv crypto.PrivateKey, payloadPath st
 
 // From assigns a clone of the provided link to its internal link
 func (lb *LinkBuilder) From(l *cs.Link) *LinkBuilder {
-	lb.Link = Clone(l)
+	lb.Link, _ = l.Clone()
 	return lb
 }
 

--- a/cs/signature.go
+++ b/cs/signature.go
@@ -17,7 +17,6 @@ package cs
 
 import (
 	cj "github.com/gibson042/canonicaljson-go"
-	jmespath "github.com/jmespath/go-jmespath"
 	"github.com/pkg/errors"
 
 	"github.com/stratumn/go-crypto/signatures"
@@ -49,7 +48,7 @@ type Signature struct {
 // NewSignature creates a new signature for a link.
 // Only the data matching the JMESPATH query will be signed
 func NewSignature(payloadPath string, privateKey []byte, l *Link) (*Signature, error) {
-	payload, err := jmespath.Search(payloadPath, l)
+	payload, err := l.Search(payloadPath)
 	if err != nil {
 		return nil, errors.Wrap(err, ErrBadJMESPATHQuery)
 	}
@@ -78,7 +77,7 @@ func NewSignature(payloadPath string, privateKey []byte, l *Link) (*Signature, e
 // Verify takes a link as input, computes the signed part using the signature payload
 // and runs the signature verification depending on its type.
 func (s Signature) Verify(l *Link) error {
-	payload, err := jmespath.Search(s.Payload, l)
+	payload, err := l.Search(s.Payload)
 	if err != nil {
 		return errors.Wrap(err, ErrBadJMESPATHQuery)
 	}

--- a/validation/validators/transition_test.go
+++ b/validation/validators/transition_test.go
@@ -157,7 +157,7 @@ func TestTransitionValidator(t *testing.T) {
 			valid: false,
 			err:   "previous segment not found.*",
 			link: func() *cs.Link {
-				l := cstesting.Clone(links.finalProduct)
+				l, _ := links.finalProduct.Clone()
 				l.Meta.PrevLinkHash = testutil.RandomHash().String()
 				return l
 			}(),


### PR DESCRIPTION
It appears that the jmespath query fails to find data in certain cases where the state contains a custom structure. To solve that issue, a wrapper has been added around the link to serialize the link to json before executing the jmespath query.