### PR TITLE
postgresstore: refacto FindSegments queries

### DIFF
--- a/postgresstore/stmts.go
+++ b/postgresstore/stmts.go
@@ -324,12 +324,12 @@ func (s *readStmts) FindSegmentsWithFilters(filter *store.SegmentFilter) (*sql.R
 	if len(filter.Tags) > 0 {
 		filters = append(filters, fmt.Sprintf("tags @>  $%d", cnt))
 		values = append(values, pq.Array(filter.Tags))
-		cnt++
 	}
 
 	sqlBody := ""
 	if len(filters) > 0 {
-		sqlBody = "\nWHERE " + strings.Join(filters, "\n AND ")
+		sqlBody = "\nWHERE "
+		sqlBody += strings.Join(filters, "\n AND ")
 	}
 
 	query := sqlHead + sqlBody + sqlTail

--- a/postgresstore/stmts.go
+++ b/postgresstore/stmts.go
@@ -14,7 +14,15 @@
 
 package postgresstore
 
-import "database/sql"
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"github.com/stratumn/go-indigocore/cs"
+	"github.com/stratumn/go-indigocore/store"
+	"github.com/stratumn/go-indigocore/types"
+)
 
 const (
 	sqlCreateLink = `
@@ -46,106 +54,6 @@ const (
 		DELETE FROM links
 		WHERE link_hash = $1
 		RETURNING data
-	`
-	sqlFindSegments = `
-		SELECT l.link_hash, l.data, e.data FROM links l
-		LEFT JOIN evidences e ON l.link_hash = e.link_hash
-		WHERE (length($3) = 0 OR process = $3)
-		ORDER BY priority DESC, l.created_at DESC
-		OFFSET $1 LIMIT $2
-	`
-	sqlFindSegmentsWithLinkHashes = `
-		SELECT l.link_hash, l.data, e.data FROM links l
-		LEFT JOIN evidences e ON l.link_hash = e.link_hash
-		WHERE l.link_hash = any($1::bytea[])
-		AND (length($4) = 0 OR process = $4)
-		ORDER BY priority DESC, l.created_at DESC
-		OFFSET $2 LIMIT $3
-	`
-	sqlFindSegmentsWithLinkHashesAndMapIDs = `
-		SELECT l.link_hash, l.data, e.data FROM links l
-		LEFT JOIN evidences e ON l.link_hash = e.link_hash
-		WHERE l.link_hash = any($1::bytea[])
-		AND map_id = any($2::text[])
-		AND (length($5) = 0 OR process = $5)
-		ORDER BY priority DESC, l.created_at DESC
-		OFFSET $3 LIMIT $4
-	`
-	sqlFindSegmentsWithLinkHashesAndTags = `
-		SELECT l.link_hash, l.data, e.data FROM links l
-		LEFT JOIN evidences e ON l.link_hash = e.link_hash
-		WHERE l.link_hash = any($1::bytea[])
-		AND tags @> $2
-		AND (length($5) = 0 OR process = $5)
-		ORDER BY priority DESC, l.created_at DESC
-		OFFSET $3 LIMIT $4
-	`
-	sqlFindSegmentsWithLinkHashesAndMapIDsAndTags = `
-		SELECT l.link_hash, l.data, e.data FROM links l
-		LEFT JOIN evidences e ON l.link_hash = e.link_hash
-		WHERE l.link_hash = any($1::bytea[])
-		AND map_id = any($2::text[]) AND tags @> $3
-		AND (length($6) = 0 OR process = $6)
-		ORDER BY priority DESC, l.created_at DESC
-		OFFSET $4 LIMIT $5
-	`
-	sqlFindSegmentsWithMapIDs = `
-		SELECT l.link_hash, l.data, e.data FROM links l
-		LEFT JOIN evidences e ON l.link_hash = e.link_hash
-		WHERE map_id = any($1::text[])
-		AND (length($4) = 0 OR process = $4)
-		ORDER BY priority DESC, l.created_at DESC
-		OFFSET $2 LIMIT $3
-	`
-	sqlFindSegmentsWithPrevLinkHash = `
-		SELECT l.link_hash, l.data, e.data FROM links l
-		LEFT JOIN evidences e ON l.link_hash = e.link_hash
-		WHERE prev_link_hash = $1
-		AND (length($4) = 0 OR process = $4)
-		ORDER BY priority DESC, l.created_at DESC
-		OFFSET $2 LIMIT $3
-	`
-	sqlFindSegmentsWithTags = `
-		SELECT l.link_hash, l.data, e.data FROM links l
-		LEFT JOIN evidences e ON l.link_hash = e.link_hash
-		WHERE tags @> $1
-		AND (length($4) = 0 OR process = $4)
-		ORDER BY priority DESC, l.created_at DESC
-		OFFSET $2 LIMIT $3
-	`
-	sqlFindSegmentsWithMapIDsAndTags = `
-		SELECT l.link_hash, l.data, e.data FROM links l
-		LEFT JOIN evidences e ON l.link_hash = e.link_hash
-		WHERE map_id = any($1::text[]) AND tags @> $2
-		AND (length($5) = 0 OR process = $5)
-		ORDER BY priority DESC, l.created_at DESC
-		OFFSET $3 LIMIT $4
-	`
-	sqlFindSegmentsWithPrevLinkHashAndTags = `
-		SELECT l.link_hash, l.data, e.data FROM links l
-		LEFT JOIN evidences e ON l.link_hash = e.link_hash
-		WHERE prev_link_hash = $1 AND tags @> $2
-		AND (length($5) = 0 OR process = $5)
-		ORDER BY priority DESC, l.created_at DESC
-		OFFSET $3 LIMIT $4
-	`
-	sqlFindSegmentsWithPrevLinkHashAndMapIDs = `
-		SELECT l.link_hash, l.data, e.data FROM links l
-		LEFT JOIN evidences e ON l.link_hash = e.link_hash
-		WHERE prev_link_hash = $1
-		AND map_id = any($2::text[])
-		AND (length($5) = 0 OR process = $5)
-		ORDER BY priority DESC, l.created_at DESC
-		OFFSET $3 LIMIT $4
-	`
-	sqlFindSegmentsWithPrevLinkHashAndMapIDsAndTags = `
-		SELECT l.link_hash, l.data, e.data FROM links l
-		LEFT JOIN evidences e ON l.link_hash = e.link_hash
-		WHERE prev_link_hash = $1
-		AND map_id = any($2::text[]) AND tags @> $3
-		AND (length($6) = 0 OR process = $6)
-		ORDER BY priority DESC, l.created_at DESC
-		OFFSET $4 LIMIT $5
 	`
 	sqlGetMapIDs = `
 		SELECT l.map_id FROM links l
@@ -274,24 +182,13 @@ type writeStmts struct {
 }
 
 type readStmts struct {
+	// DB.Query or Tx.Query depending on if we are in batch.
+	query func(query string, args ...interface{}) (*sql.Rows, error)
+
 	GetSegment   *sql.Stmt
-	FindSegments *sql.Stmt
 	GetMapIDs    *sql.Stmt
 	GetValue     *sql.Stmt
 	GetEvidences *sql.Stmt
-
-	FindSegmentsWithMapIDs                       *sql.Stmt
-	FindSegmentsWithPrevLinkHash                 *sql.Stmt
-	FindSegmentsWithTags                         *sql.Stmt
-	FindSegmentsWithLinkHashes                   *sql.Stmt
-	FindSegmentsWithLinkHashesAndMapIDs          *sql.Stmt
-	FindSegmentsWithLinkHashesAndTags            *sql.Stmt
-	FindSegmentsWithLinkHashesAndMapIDsAndTags   *sql.Stmt
-	FindSegmentsWithTagsAndLimit                 *sql.Stmt
-	FindSegmentsWithMapIDsAndTags                *sql.Stmt
-	FindSegmentsWithPrevLinkHashAndTags          *sql.Stmt
-	FindSegmentsWithPrevLinkHashAndMapIDs        *sql.Stmt
-	FindSegmentsWithPrevLinkHashAndMapIDsAndTags *sql.Stmt
 }
 
 type stmts struct {
@@ -315,24 +212,9 @@ func newStmts(db *sql.DB) (*stmts, error) {
 	}
 
 	s.GetSegment = prepare(sqlGetSegment)
-	s.FindSegments = prepare(sqlFindSegments)
 	s.GetMapIDs = prepare(sqlGetMapIDs)
 	s.GetValue = prepare(sqlGetValue)
 	s.GetEvidences = prepare(sqlGetEvidences)
-
-	s.FindSegmentsWithMapIDs = prepare(sqlFindSegmentsWithMapIDs)
-	s.FindSegmentsWithPrevLinkHash = prepare(sqlFindSegmentsWithPrevLinkHash)
-	s.FindSegmentsWithTags = prepare(sqlFindSegmentsWithTags)
-
-	s.FindSegmentsWithLinkHashes = prepare(sqlFindSegmentsWithLinkHashes)
-	s.FindSegmentsWithLinkHashesAndMapIDs = prepare(sqlFindSegmentsWithLinkHashesAndMapIDs)
-	s.FindSegmentsWithLinkHashesAndTags = prepare(sqlFindSegmentsWithLinkHashesAndTags)
-	s.FindSegmentsWithLinkHashesAndMapIDsAndTags = prepare(sqlFindSegmentsWithLinkHashesAndMapIDsAndTags)
-
-	s.FindSegmentsWithMapIDsAndTags = prepare(sqlFindSegmentsWithMapIDsAndTags)
-	s.FindSegmentsWithPrevLinkHashAndTags = prepare(sqlFindSegmentsWithPrevLinkHashAndTags)
-	s.FindSegmentsWithPrevLinkHashAndMapIDs = prepare(sqlFindSegmentsWithPrevLinkHashAndMapIDs)
-	s.FindSegmentsWithPrevLinkHashAndMapIDsAndTags = prepare(sqlFindSegmentsWithPrevLinkHashAndMapIDsAndTags)
 
 	s.CreateLink = prepare(sqlCreateLink)
 	s.DeleteLink = prepare(sqlDeleteLink)
@@ -343,6 +225,8 @@ func newStmts(db *sql.DB) (*stmts, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	s.query = db.Query
 
 	return &s, nil
 }
@@ -361,7 +245,6 @@ func newBatchStmts(tx *sql.Tx) (*batchStmts, error) {
 	}
 
 	s.GetSegment = prepare(sqlGetSegment)
-	s.FindSegments = prepare(sqlFindSegments)
 	s.GetMapIDs = prepare(sqlGetMapIDs)
 	s.GetValue = prepare(sqlGetValue)
 
@@ -374,5 +257,77 @@ func newBatchStmts(tx *sql.Tx) (*batchStmts, error) {
 		return nil, err
 	}
 
+	s.query = tx.Query
+
 	return &s, nil
+}
+
+// FindSegments formats a read query and retrives segments according to the filter.
+func (s *readStmts) FindSegmentsWithFilters(filter *store.SegmentFilter) (*sql.Rows, error) {
+	query, err := formatFindSegmentsQuery(filter)
+	if err != nil {
+		return nil, err
+	}
+	return s.query(query)
+}
+
+func formatFindSegmentsQuery(filter *store.SegmentFilter) (string, error) {
+	sqlHead := `
+		SELECT l.link_hash, l.data, e.data FROM links l
+		LEFT JOIN evidences e ON l.link_hash = e.link_hash
+	`
+
+	sqlTail := fmt.Sprintf(`
+		ORDER BY priority DESC, l.created_at DESC
+		OFFSET %d LIMIT %d
+		`,
+		filter.Pagination.Offset,
+		filter.Pagination.Limit,
+	)
+
+	filters := []string{}
+
+	if len(filter.MapIDs) > 0 {
+		f := fmt.Sprintf("map_id IN ('%s')", strings.Join(filter.MapIDs, "','"))
+		filters = append(filters, f)
+	}
+
+	if filter.Process != "" {
+		f := fmt.Sprintf("process = '%s'", filter.Process)
+		filters = append(filters, f)
+	}
+
+	if filter.PrevLinkHash != nil {
+		var prevLinkHash []byte
+		if prevLinkHashBytes, err := types.NewBytes32FromString(*filter.PrevLinkHash); prevLinkHashBytes != nil && err == nil {
+			prevLinkHash = prevLinkHashBytes[:]
+		}
+		f := fmt.Sprintf("prev_link_hash = '\\x%x'", prevLinkHash)
+		filters = append(filters, f)
+	}
+
+	if len(filter.LinkHashes) > 0 {
+		linkHashes, err := cs.NewLinkHashesFromStrings(filter.LinkHashes)
+		if err != nil {
+			return "", err
+		}
+		linkHashStrings := make([]string, len(linkHashes))
+		for i, lh := range linkHashes {
+			linkHashStrings[i] = fmt.Sprintf("'\\x%x'", lh[:])
+		}
+		f := fmt.Sprintf("l.link_hash IN (%s)", strings.Join(linkHashStrings, ","))
+		filters = append(filters, f)
+	}
+
+	if len(filter.Tags) > 0 {
+		f := fmt.Sprintf("tags @> ARRAY['%s']::text[]", strings.Join(filter.Tags, "','"))
+		filters = append(filters, f)
+	}
+
+	sqlBody := ""
+	if len(filters) > 0 {
+		sqlBody = "\nWHERE " + strings.Join(filters, "\n AND ")
+	}
+
+	return sqlHead + sqlBody + sqlTail, nil
 }

--- a/store/storetestcases/findsegments.go
+++ b/store/storetestcases/findsegments.go
@@ -377,6 +377,28 @@ func (f Factory) TestFindSegments(t *testing.T) {
 		assert.True(t, len(got[0].Meta.Evidences) >= 4)
 	})
 
+	t.Run("Resists to SQL injections in process filter", func(t *testing.T) {
+		ctx := context.Background()
+		slice, err := a.FindSegments(ctx, &store.SegmentFilter{
+			Pagination: store.Pagination{
+				Limit: segmentsTotalCount,
+			},
+			Process: "Foo' or 'bar' = 'bar'--",
+		})
+		verifyResultsCount(t, err, slice, 0)
+	})
+
+	t.Run("Resists to SQL injections in mapIDs filter", func(t *testing.T) {
+		ctx := context.Background()
+		slice, err := a.FindSegments(ctx, &store.SegmentFilter{
+			Pagination: store.Pagination{
+				Limit: segmentsTotalCount,
+			},
+			MapIDs: []string{"Foo') or 'bar' = 'bar'--", "plap"},
+		})
+		verifyResultsCount(t, err, slice, 0)
+	})
+
 }
 
 // BenchmarkFindSegments benchmarks finding segments.


### PR DESCRIPTION
Replace all the precompiled statements by building the query in function of the filters.

- the choice of keeping the sql query raw (in comparison with using an ORM) was made for performance.
- we use db.Query / tx.Query with an already assembled query string (instead of passing a formatting string and all placeholder values) for performance. Indeed, when we use the Query() with a single argument, we bypass the prepare --> execute --> close sequence that's done behind the scenes when pasding multiple args

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/go-indigocore/427)
<!-- Reviewable:end -->
