### PR TITLE
tmpop: skip errored evidence

### DIFF
--- a/tmpop/tmpop.go
+++ b/tmpop/tmpop.go
@@ -532,11 +532,13 @@ func (t *TMPop) addTendermintEvidence(ctx context.Context, header *abci.Header) 
 			if err != nil {
 				log.Warnf("Evidence could not be created: %v", err)
 				span.Annotatef(nil, "Evidence for %x could not be created: %s", linkHash.String(), err.Error())
+				continue
 			}
 
 			if err := t.adapter.AddEvidence(ctx, linkHash, evidence); err != nil {
 				log.Warnf("Evidence could not be added to local store: %v", err)
 				span.Annotatef(nil, "Evidence for %x could not be added: %s", linkHash.String(), err.Error())
+				continue
 			}
 
 			if evidence != nil {


### PR DESCRIPTION
If the evidence ends up null because of an error, this will cause a nullref in the AddEvidence.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/go-indigocore/438)
<!-- Reviewable:end -->
