### PR TITLE
filters: link hash should be bytes

### DIFF
--- a/couchstore/queries.go
+++ b/couchstore/queries.go
@@ -82,9 +82,13 @@ func NewSegmentQuery(filter *store.SegmentFilter) ([]byte, error) {
 	linkSelector := LinkSelector{}
 	linkSelector.ObjectType = objectTypeLink
 
-	if filter.PrevLinkHash != nil {
+	if filter.WithoutParent {
 		linkSelector.PrevLinkHash = &PrevLinkHash{
-			Equals: *filter.PrevLinkHash,
+			Equals: "",
+		}
+	} else if len(filter.PrevLinkHash) > 0 {
+		linkSelector.PrevLinkHash = &PrevLinkHash{
+			Equals: filter.PrevLinkHash.String(),
 		}
 	}
 	if filter.Process != "" {
@@ -97,8 +101,9 @@ func NewSegmentQuery(filter *store.SegmentFilter) ([]byte, error) {
 		linkSelector.Tags = &TagsAll{Tags: filter.Tags}
 	}
 	if len(filter.LinkHashes) > 0 {
-		linkSelector.LinkHash = &LinkHashIn{
-			LinkHashes: filter.LinkHashes,
+		linkSelector.LinkHash = &LinkHashIn{}
+		for _, lh := range filter.LinkHashes {
+			linkSelector.LinkHash.LinkHashes = append(linkSelector.LinkHash.LinkHashes, lh.String())
 		}
 	}
 

--- a/elasticsearchstore/api.go
+++ b/elasticsearchstore/api.go
@@ -287,14 +287,14 @@ func fromLink(link *chainscript.Link) (*linkDoc, error) {
 	return &doc, nil
 }
 
-func (es *ESStore) createLink(link *chainscript.Link) (chainscript.LinkHash, error) {
+func (es *ESStore) createLink(ctx context.Context, link *chainscript.Link) (chainscript.LinkHash, error) {
 	linkHash, err := link.Hash()
 	if err != nil {
 		return nil, err
 	}
 	linkHashStr := linkHash.String()
 
-	has, err := es.hasDocument(linksIndex, linkHashStr)
+	has, err := es.hasDocument(ctx, linksIndex, linkHashStr)
 	if err != nil {
 		return nil, err
 	}
@@ -308,29 +308,27 @@ func (es *ESStore) createLink(link *chainscript.Link) (chainscript.LinkHash, err
 		return nil, err
 	}
 
-	return linkHash, es.indexDocument(linksIndex, linkHashStr, linkDoc)
+	return linkHash, es.indexDocument(ctx, linksIndex, linkHashStr, linkDoc)
 }
 
-func (es *ESStore) hasDocument(indexName, id string) (bool, error) {
-	ctx := context.TODO()
+func (es *ESStore) hasDocument(ctx context.Context, indexName, id string) (bool, error) {
 	return es.client.Exists().Index(indexName).Type(docType).Id(id).Do(ctx)
 }
 
-func (es *ESStore) indexDocument(indexName, id string, doc interface{}) error {
-	ctx := context.TODO()
+func (es *ESStore) indexDocument(ctx context.Context, indexName, id string, doc interface{}) error {
 	_, err := es.client.Index().Index(indexName).Type(docType).Id(id).BodyJson(doc).Do(ctx)
 	return err
 }
 
-func (es *ESStore) getDocument(indexName, id string) (*json.RawMessage, error) {
-	has, err := es.hasDocument(indexName, id)
+func (es *ESStore) getDocument(ctx context.Context, indexName, id string) (*json.RawMessage, error) {
+	has, err := es.hasDocument(ctx, indexName, id)
 	if err != nil {
 		return nil, err
 	}
 	if !has {
 		return nil, nil
 	}
-	ctx := context.TODO()
+
 	get, err := es.client.Get().Index(indexName).Type(docType).Id(id).Do(ctx)
 	if err != nil {
 		return nil, err
@@ -342,15 +340,14 @@ func (es *ESStore) getDocument(indexName, id string) (*json.RawMessage, error) {
 	return get.Source, nil
 }
 
-func (es *ESStore) deleteDocument(indexName, id string) error {
-	ctx := context.TODO()
+func (es *ESStore) deleteDocument(ctx context.Context, indexName, id string) error {
 	_, err := es.client.Delete().Index(indexName).Type(docType).Id(id).Do(ctx)
 	return err
 }
 
-func (es *ESStore) getLink(id string) (*chainscript.Link, error) {
+func (es *ESStore) getLink(ctx context.Context, id string) (*chainscript.Link, error) {
 	var link linkDoc
-	jsn, err := es.getDocument(linksIndex, id)
+	jsn, err := es.getDocument(ctx, linksIndex, id)
 	if err != nil {
 		return nil, err
 	}
@@ -361,8 +358,8 @@ func (es *ESStore) getLink(id string) (*chainscript.Link, error) {
 	return &link.Link, err
 }
 
-func (es *ESStore) getEvidences(id string) (types.EvidenceSlice, error) {
-	jsn, err := es.getDocument(evidencesIndex, id)
+func (es *ESStore) getEvidences(ctx context.Context, id string) (types.EvidenceSlice, error) {
+	jsn, err := es.getDocument(ctx, evidencesIndex, id)
 	if err != nil {
 		return nil, err
 	}
@@ -373,8 +370,8 @@ func (es *ESStore) getEvidences(id string) (types.EvidenceSlice, error) {
 	return evidences.Evidences, err
 }
 
-func (es *ESStore) addEvidence(linkHash string, evidence *chainscript.Evidence) error {
-	currentDoc, err := es.getEvidences(linkHash)
+func (es *ESStore) addEvidence(ctx context.Context, linkHash string, evidence *chainscript.Evidence) error {
+	currentDoc, err := es.getEvidences(ctx, linkHash)
 	if err != nil {
 		return err
 	}
@@ -387,12 +384,12 @@ func (es *ESStore) addEvidence(linkHash string, evidence *chainscript.Evidence) 
 		Evidences: currentDoc,
 	}
 
-	return es.indexDocument(evidencesIndex, linkHash, &evidences)
+	return es.indexDocument(ctx, evidencesIndex, linkHash, &evidences)
 }
 
-func (es *ESStore) getValue(key string) ([]byte, error) {
+func (es *ESStore) getValue(ctx context.Context, key string) ([]byte, error) {
 	var value Value
-	jsn, err := es.getDocument(valuesIndex, key)
+	jsn, err := es.getDocument(ctx, valuesIndex, key)
 	if err != nil {
 		return nil, err
 	}
@@ -402,15 +399,15 @@ func (es *ESStore) getValue(key string) ([]byte, error) {
 	return value.Value, err
 }
 
-func (es *ESStore) setValue(key string, value []byte) error {
+func (es *ESStore) setValue(ctx context.Context, key string, value []byte) error {
 	v := Value{
 		Value: value,
 	}
-	return es.indexDocument(valuesIndex, key, v)
+	return es.indexDocument(ctx, valuesIndex, key, v)
 }
 
-func (es *ESStore) deleteValue(key string) ([]byte, error) {
-	value, err := es.getValue(key)
+func (es *ESStore) deleteValue(ctx context.Context, key string) ([]byte, error) {
+	value, err := es.getValue(ctx, key)
 	if err != nil {
 		return nil, err
 	}
@@ -419,7 +416,7 @@ func (es *ESStore) deleteValue(key string) ([]byte, error) {
 		return nil, nil
 	}
 
-	return value, es.deleteDocument(valuesIndex, key)
+	return value, es.deleteDocument(ctx, valuesIndex, key)
 }
 
 func (es *ESStore) segmentify(ctx context.Context, link *chainscript.Link) *chainscript.Segment {
@@ -435,9 +432,8 @@ func (es *ESStore) segmentify(ctx context.Context, link *chainscript.Link) *chai
 	return segment
 }
 
-func (es *ESStore) getMapIDs(filter *store.MapFilter) ([]string, error) {
+func (es *ESStore) getMapIDs(ctx context.Context, filter *store.MapFilter) ([]string, error) {
 	// Flush to make sure the documents got written.
-	ctx := context.TODO()
 	_, err := es.client.Flush().Index(linksIndex).Do(ctx)
 	if err != nil {
 		return nil, err
@@ -498,8 +494,11 @@ func makeFilterQueries(filter *store.SegmentFilter) []elastic.Query {
 	filterQueries := []elastic.Query{}
 
 	// prevLinkHash filter.
-	if filter.PrevLinkHash != nil {
-		q := elastic.NewTermQuery("prevLinkHash.keyword", *filter.PrevLinkHash)
+	if filter.WithoutParent {
+		q := elastic.NewTermQuery("prevLinkHash.keyword", "")
+		filterQueries = append(filterQueries, q)
+	} else if filter.PrevLinkHash != nil {
+		q := elastic.NewTermQuery("prevLinkHash.keyword", filter.PrevLinkHash.String())
 		filterQueries = append(filterQueries, q)
 	}
 
@@ -533,16 +532,20 @@ func makeFilterQueries(filter *store.SegmentFilter) []elastic.Query {
 
 	// linkHashes filter.
 	if len(filter.LinkHashes) > 0 {
-		q := elastic.NewIdsQuery(docType).Ids(filter.LinkHashes...)
+		lhs := make([]string, len(filter.LinkHashes))
+		for i, lh := range filter.LinkHashes {
+			lhs[i] = lh.String()
+		}
+
+		q := elastic.NewIdsQuery(docType).Ids(lhs...)
 		filterQueries = append(filterQueries, q)
 	}
 
 	return filterQueries
 }
 
-func (es *ESStore) genericSearch(filter *store.SegmentFilter, q elastic.Query) (*types.PaginatedSegments, error) {
+func (es *ESStore) genericSearch(ctx context.Context, filter *store.SegmentFilter, q elastic.Query) (*types.PaginatedSegments, error) {
 	// Flush to make sure the documents got written.
-	ctx := context.TODO()
 	_, err := es.client.Flush().Index(linksIndex).Do(ctx)
 	if err != nil {
 		return nil, err
@@ -588,15 +591,15 @@ func (es *ESStore) genericSearch(filter *store.SegmentFilter, q elastic.Query) (
 	return res, nil
 }
 
-func (es *ESStore) findSegments(filter *store.SegmentFilter) (*types.PaginatedSegments, error) {
+func (es *ESStore) findSegments(ctx context.Context, filter *store.SegmentFilter) (*types.PaginatedSegments, error) {
 	// prepare query.
 	q := elastic.NewBoolQuery().Filter(makeFilterQueries(filter)...)
 
 	// run search.
-	return es.genericSearch(filter, q)
+	return es.genericSearch(ctx, filter, q)
 }
 
-func (es *ESStore) simpleSearchQuery(query *SearchQuery) (*types.PaginatedSegments, error) {
+func (es *ESStore) simpleSearchQuery(ctx context.Context, query *SearchQuery) (*types.PaginatedSegments, error) {
 	// prepare Query.
 	q := elastic.NewBoolQuery().
 		// add filter queries.
@@ -605,10 +608,10 @@ func (es *ESStore) simpleSearchQuery(query *SearchQuery) (*types.PaginatedSegmen
 		Must(elastic.NewSimpleQueryStringQuery(query.Query))
 
 	// run search.
-	return es.genericSearch(&query.SegmentFilter, q)
+	return es.genericSearch(ctx, &query.SegmentFilter, q)
 }
 
-func (es *ESStore) multiMatchQuery(query *SearchQuery) (*types.PaginatedSegments, error) {
+func (es *ESStore) multiMatchQuery(ctx context.Context, query *SearchQuery) (*types.PaginatedSegments, error) {
 	// fields to search through: all meta + dataTokens.
 	fields := []string{
 		"meta.mapId",
@@ -624,5 +627,5 @@ func (es *ESStore) multiMatchQuery(query *SearchQuery) (*types.PaginatedSegments
 	q := elastic.NewMultiMatchQuery(query.Query, fields...).Type("best_fields")
 
 	// run search.
-	return es.genericSearch(&query.SegmentFilter, q)
+	return es.genericSearch(ctx, &query.SegmentFilter, q)
 }

--- a/elasticsearchstore/api.go
+++ b/elasticsearchstore/api.go
@@ -497,7 +497,7 @@ func makeFilterQueries(filter *store.SegmentFilter) []elastic.Query {
 	if filter.WithoutParent {
 		q := elastic.NewTermQuery("prevLinkHash.keyword", "")
 		filterQueries = append(filterQueries, q)
-	} else if filter.PrevLinkHash != nil {
+	} else if len(filter.PrevLinkHash) > 0 {
 		q := elastic.NewTermQuery("prevLinkHash.keyword", filter.PrevLinkHash.String())
 		filterQueries = append(filterQueries, q)
 	}

--- a/elasticsearchstore/elasticsearchstore.go
+++ b/elasticsearchstore/elasticsearchstore.go
@@ -153,7 +153,7 @@ func (es *ESStore) NewBatch(ctx context.Context) (store.Batch, error) {
 
 // CreateLink implements github.com/stratumn/go-indigocore/store.LinkWriter.CreateLink.
 func (es *ESStore) CreateLink(ctx context.Context, link *chainscript.Link) (chainscript.LinkHash, error) {
-	linkHash, err := es.createLink(link)
+	linkHash, err := es.createLink(ctx, link)
 	if err != nil {
 		return nil, err
 	}
@@ -167,7 +167,7 @@ func (es *ESStore) CreateLink(ctx context.Context, link *chainscript.Link) (chai
 
 // AddEvidence implements github.com/stratumn/go-indigocore/store.EvidenceWriter.AddEvidence.
 func (es *ESStore) AddEvidence(ctx context.Context, linkHash chainscript.LinkHash, evidence *chainscript.Evidence) error {
-	if err := es.addEvidence(linkHash.String(), evidence); err != nil {
+	if err := es.addEvidence(ctx, linkHash.String(), evidence); err != nil {
 		return err
 	}
 
@@ -183,7 +183,7 @@ func (es *ESStore) AddEvidence(ctx context.Context, linkHash chainscript.LinkHas
 
 // GetSegment implements github.com/stratumn/go-indigocore/store.Adapter.GetSegment.
 func (es *ESStore) GetSegment(ctx context.Context, linkHash chainscript.LinkHash) (*chainscript.Segment, error) {
-	link, err := es.getLink(linkHash.String())
+	link, err := es.getLink(ctx, linkHash.String())
 	if err != nil || link == nil {
 		return nil, err
 	}
@@ -192,17 +192,17 @@ func (es *ESStore) GetSegment(ctx context.Context, linkHash chainscript.LinkHash
 
 // FindSegments implements github.com/stratumn/go-indigocore/store.Adapter.FindSegments.
 func (es *ESStore) FindSegments(ctx context.Context, filter *store.SegmentFilter) (*types.PaginatedSegments, error) {
-	return es.findSegments(filter)
+	return es.findSegments(ctx, filter)
 }
 
 // GetMapIDs implements github.com/stratumn/go-indigocore/store.Adapter.GetMapIDs.
 func (es *ESStore) GetMapIDs(ctx context.Context, filter *store.MapFilter) ([]string, error) {
-	return es.getMapIDs(filter)
+	return es.getMapIDs(ctx, filter)
 }
 
 // GetEvidences implements github.com/stratumn/go-indigocore/store.EvidenceReader.GetEvidences.
 func (es *ESStore) GetEvidences(ctx context.Context, linkHash chainscript.LinkHash) (types.EvidenceSlice, error) {
-	return es.getEvidences(linkHash.String())
+	return es.getEvidences(ctx, linkHash.String())
 }
 
 /********** github.com/stratumn/go-indigocore/store.KeyValueStore implementation **********/
@@ -210,19 +210,19 @@ func (es *ESStore) GetEvidences(ctx context.Context, linkHash chainscript.LinkHa
 // SetValue implements github.com/stratumn/go-indigocore/store.KeyValueStore.SetValue.
 func (es *ESStore) SetValue(ctx context.Context, key, value []byte) error {
 	hexKey := hex.EncodeToString(key)
-	return es.setValue(hexKey, value)
+	return es.setValue(ctx, hexKey, value)
 }
 
 // GetValue implements github.com/stratumn/go-indigocore/store.Adapter.GetValue.
 func (es *ESStore) GetValue(ctx context.Context, key []byte) ([]byte, error) {
 	hexKey := hex.EncodeToString(key)
-	return es.getValue(hexKey)
+	return es.getValue(ctx, hexKey)
 }
 
 // DeleteValue implements github.com/stratumn/go-indigocore/store.Adapter.DeleteValue.
 func (es *ESStore) DeleteValue(ctx context.Context, key []byte) ([]byte, error) {
 	hexKey := hex.EncodeToString(key)
-	return es.deleteValue(hexKey)
+	return es.deleteValue(ctx, hexKey)
 
 }
 
@@ -230,12 +230,12 @@ func (es *ESStore) DeleteValue(ctx context.Context, key []byte) ([]byte, error) 
 
 // SimpleSearchQuery searches through the store for segments matching query criteria
 // using ES simple query string feature
-func (es *ESStore) SimpleSearchQuery(query *SearchQuery) (*types.PaginatedSegments, error) {
-	return es.simpleSearchQuery(query)
+func (es *ESStore) SimpleSearchQuery(ctx context.Context, query *SearchQuery) (*types.PaginatedSegments, error) {
+	return es.simpleSearchQuery(ctx, query)
 }
 
 // MultiMatchQuery searches through the store for segments matching query criteria
 // using ES multi match query
-func (es *ESStore) MultiMatchQuery(query *SearchQuery) (*types.PaginatedSegments, error) {
-	return es.multiMatchQuery(query)
+func (es *ESStore) MultiMatchQuery(ctx context.Context, query *SearchQuery) (*types.PaginatedSegments, error) {
+	return es.multiMatchQuery(ctx, query)
 }

--- a/elasticsearchstore/elasticsearchstore_test.go
+++ b/elasticsearchstore/elasticsearchstore_test.go
@@ -158,71 +158,80 @@ func TestElasticSearchStoreSearch(t *testing.T) {
 	hash2, _ := link2.Hash()
 
 	t.Run("Simple Search Query", func(t *testing.T) {
-
 		t.Run("Should find segment based on partial state match", func(t *testing.T) {
-			slice, err := a.SimpleSearchQuery(&SearchQuery{
-				SegmentFilter: store.SegmentFilter{
-					Pagination: store.Pagination{
-						Limit: 5,
+			slice, err := a.SimpleSearchQuery(
+				context.Background(),
+				&SearchQuery{
+					SegmentFilter: store.SegmentFilter{
+						Pagination: store.Pagination{
+							Limit: 5,
+						},
 					},
-				},
-				Query: "sala*",
-			})
+					Query: "sala*",
+				})
 			verifyResultsCount(t, err, slice, 1)
 			assert.Equal(t, hash1, slice.Segments[0].LinkHash(), "Wrong link was found")
 		})
 
 		t.Run("Should find segment based on mapId", func(t *testing.T) {
-			slice, err := a.SimpleSearchQuery(&SearchQuery{
-				SegmentFilter: store.SegmentFilter{
-					Pagination: store.Pagination{
-						Limit: 5,
+			slice, err := a.SimpleSearchQuery(
+				context.Background(),
+				&SearchQuery{
+					SegmentFilter: store.SegmentFilter{
+						Pagination: store.Pagination{
+							Limit: 5,
+						},
 					},
-				},
-				Query: "emirates",
-			})
+					Query: "emirates",
+				})
 			verifyResultsCount(t, err, slice, 1)
 			assert.Equal(t, hash2, slice.Segments[0].LinkHash(), "Wrong link was found")
 		})
 
 		t.Run("Should filter on Process", func(t *testing.T) {
-			slice, err := a.SimpleSearchQuery(&SearchQuery{
-				SegmentFilter: store.SegmentFilter{
-					Pagination: store.Pagination{
-						Limit: 5,
+			slice, err := a.SimpleSearchQuery(
+				context.Background(),
+				&SearchQuery{
+					SegmentFilter: store.SegmentFilter{
+						Pagination: store.Pagination{
+							Limit: 5,
+						},
+						Process: "fly emirates",
 					},
-					Process: "fly emirates",
-				},
-				Query: "stratu*",
-			})
+					Query: "stratu*",
+				})
 			verifyResultsCount(t, err, slice, 1)
 			assert.Equal(t, hash2, slice.Segments[0].LinkHash(), "Wrong link was found")
 		})
 
 		t.Run("Should filter on one MapId", func(t *testing.T) {
-			slice, err := a.SimpleSearchQuery(&SearchQuery{
-				SegmentFilter: store.SegmentFilter{
-					Pagination: store.Pagination{
-						Limit: 5,
+			slice, err := a.SimpleSearchQuery(
+				context.Background(),
+				&SearchQuery{
+					SegmentFilter: store.SegmentFilter{
+						Pagination: store.Pagination{
+							Limit: 5,
+						},
+						MapIDs: []string{"foo bar"},
 					},
-					MapIDs: []string{"foo bar"},
-				},
-				Query: "stratu*",
-			})
+					Query: "stratu*",
+				})
 			verifyResultsCount(t, err, slice, 1)
 			assert.Equal(t, hash1, slice.Segments[0].LinkHash(), "Wrong link was found")
 		})
 
 		t.Run("Should filter on multiple MapIds", func(t *testing.T) {
-			slice, err := a.SimpleSearchQuery(&SearchQuery{
-				SegmentFilter: store.SegmentFilter{
-					Pagination: store.Pagination{
-						Limit: 5,
+			slice, err := a.SimpleSearchQuery(
+				context.Background(),
+				&SearchQuery{
+					SegmentFilter: store.SegmentFilter{
+						Pagination: store.Pagination{
+							Limit: 5,
+						},
+						MapIDs: []string{"foo bar", "stupid madness"},
 					},
-					MapIDs: []string{"foo bar", "stupid madness"},
-				},
-				Query: "stratu*",
-			})
+					Query: "stratu*",
+				})
 			verifyResultsCount(t, err, slice, 2)
 			h1, h2 := slice.Segments[0].LinkHash(), slice.Segments[1].LinkHash()
 			assert.Contains(t, []chainscript.LinkHash{hash1, hash2}, h1, "Wrong link was found")
@@ -233,14 +242,16 @@ func TestElasticSearchStoreSearch(t *testing.T) {
 
 	t.Run("Multi Match Query", func(t *testing.T) {
 		t.Run("Should find segments based on multiple words", func(t *testing.T) {
-			slice, err := a.MultiMatchQuery(&SearchQuery{
-				SegmentFilter: store.SegmentFilter{
-					Pagination: store.Pagination{
-						Limit: 5,
+			slice, err := a.MultiMatchQuery(
+				context.Background(),
+				&SearchQuery{
+					SegmentFilter: store.SegmentFilter{
+						Pagination: store.Pagination{
+							Limit: 5,
+						},
 					},
-				},
-				Query: "salazar daniel",
-			})
+					Query: "salazar daniel",
+				})
 			verifyResultsCount(t, err, slice, 2)
 			h1, h2 := slice.Segments[0].LinkHash(), slice.Segments[1].LinkHash()
 			assert.Contains(t, []chainscript.LinkHash{hash1, hash2}, h1, "Wrong link was found")

--- a/postgresstore/stmts.go
+++ b/postgresstore/stmts.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 
 	"github.com/lib/pq"
-	"github.com/stratumn/go-chainscript"
 	"github.com/stratumn/go-indigocore/store"
 	"github.com/stratumn/go-indigocore/types"
 )
@@ -348,30 +347,18 @@ func (s *readStmts) FindSegmentsWithFilters(filter *store.SegmentFilter) (*sql.R
 		cnt++
 	}
 
-	if filter.PrevLinkHash != nil {
-		if *filter.PrevLinkHash == "" {
-			filters = append(filters, "prev_link_hash = '\\x'")
-		} else {
-			prevLinkHashBytes, err := chainscript.NewLinkHashFromString(*filter.PrevLinkHash)
-			if err != nil {
-				return nil, err
-			}
-
-			filters = append(filters, fmt.Sprintf("prev_link_hash = $%d", cnt))
-			values = append(values, prevLinkHashBytes)
-			cnt++
-		}
+	if filter.WithoutParent {
+		filters = append(filters, "prev_link_hash = '\\x'")
+	} else if filter.PrevLinkHash != nil {
+		filters = append(filters, fmt.Sprintf("prev_link_hash = $%d", cnt))
+		values = append(values, filter.PrevLinkHash)
+		cnt++
 	}
 
 	if len(filter.LinkHashes) > 0 {
 		var linkHashes []*types.Bytes32
 		for _, lh := range filter.LinkHashes {
-			linkHash, err := types.NewBytes32FromString(lh)
-			if err != nil {
-				return nil, err
-			}
-
-			linkHashes = append(linkHashes, linkHash)
+			linkHashes = append(linkHashes, types.NewBytes32FromBytes(lh))
 		}
 
 		filters = append(filters, fmt.Sprintf("l.link_hash = ANY($%d::bytea[])", cnt))

--- a/postgresstore/stmts.go
+++ b/postgresstore/stmts.go
@@ -349,7 +349,7 @@ func (s *readStmts) FindSegmentsWithFilters(filter *store.SegmentFilter) (*sql.R
 
 	if filter.WithoutParent {
 		filters = append(filters, "prev_link_hash = '\\x'")
-	} else if filter.PrevLinkHash != nil {
+	} else if len(filter.PrevLinkHash) > 0 {
 		filters = append(filters, fmt.Sprintf("prev_link_hash = $%d", cnt))
 		values = append(values, filter.PrevLinkHash)
 		cnt++

--- a/rethinkstore/rethinkstore.go
+++ b/rethinkstore/rethinkstore.go
@@ -209,7 +209,7 @@ func (a *Store) CreateLink(ctx context.Context, link *chainscript.Link) (chainsc
 		Process:   link.Meta.Process.Name,
 	}
 
-	if prevLinkHash != nil {
+	if len(prevLinkHash) > 0 {
 		w.PrevLinkHash = prevLinkHash
 	}
 
@@ -260,8 +260,8 @@ func (a *Store) FindSegments(ctx context.Context, filter *store.SegmentFilter) (
 	var prevLinkHash []byte
 	q := a.links
 
-	if filter.WithoutParent || filter.PrevLinkHash != nil {
-		if filter.PrevLinkHash != nil {
+	if filter.WithoutParent || len(filter.PrevLinkHash) > 0 {
+		if len(filter.PrevLinkHash) > 0 {
 			prevLinkHash = filter.PrevLinkHash
 		}
 
@@ -299,7 +299,7 @@ func (a *Store) FindSegments(ctx context.Context, filter *store.SegmentFilter) (
 		q = q.Filter(func(row rethink.Term) interface{} {
 			return rethink.Expr(ids).Contains(row.Field("mapId"))
 		})
-	} else if prevLinkHash := filter.PrevLinkHash; prevLinkHash != nil || filter.WithoutParent {
+	} else if prevLinkHash := filter.PrevLinkHash; len(prevLinkHash) > 0 || filter.WithoutParent {
 		q = q.OrderBy(rethink.OrderByOpts{Index: "prevLinkHashOrder"})
 	} else if linkHashes := filter.LinkHashes; len(linkHashes) > 0 {
 		q = q.OrderBy(rethink.Asc("id"))

--- a/store/storehttp/errors.go
+++ b/store/storehttp/errors.go
@@ -35,6 +35,13 @@ func newErrLimit(msg string) jsonhttp.ErrHTTP {
 	return jsonhttp.NewErrBadRequest(msg)
 }
 
+func newErrWithoutParent(msg string) jsonhttp.ErrHTTP {
+	if msg == "" {
+		msg = "withoutParent should be a boolean"
+	}
+	return jsonhttp.NewErrBadRequest(msg)
+}
+
 func newErrPrevLinkHash(msg string) jsonhttp.ErrHTTP {
 	if msg == "" {
 		msg = "prevLinkHash must be a 64 byte long hexadecimal string"

--- a/store/storetestcases/benchutil.go
+++ b/store/storetestcases/benchutil.go
@@ -23,7 +23,6 @@ import (
 	"github.com/stratumn/go-chainscript"
 	"github.com/stratumn/go-chainscript/chainscripttest"
 	"github.com/stratumn/go-indigocore/store"
-	"github.com/stratumn/go-indigocore/types"
 )
 
 // CreateLinkFunc is a type for a function that creates a link for benchmarks.
@@ -170,14 +169,14 @@ func RandomFilterOffsetMapIDs(b *testing.B, numLinks, i int) *store.SegmentFilte
 // random offset and previous link hash.
 // The previous link hash will be one of ten possible values.
 func RandomFilterOffsetPrevLinkHash(b *testing.B, numLinks, i int) *store.SegmentFilter {
-	prevLinkHash, _ := types.NewBytes32FromString(fmt.Sprintf("000000000000000000000000000000000000000000000000000000000000000%d", i%10))
-	prevLinkHashStr := prevLinkHash.String()
+	prevLinkHash, _ := chainscript.NewLinkHashFromString(fmt.Sprintf("000000000000000000000000000000000000000000000000000000000000000%d", i%10))
+
 	return &store.SegmentFilter{
 		Pagination: store.Pagination{
 			Offset: rand.Int() % numLinks,
 			Limit:  store.DefaultLimit,
 		},
-		PrevLinkHash: &prevLinkHashStr,
+		PrevLinkHash: prevLinkHash,
 	}
 }
 
@@ -214,14 +213,14 @@ func RandomFilterOffsetMapIDTags(b *testing.B, numLinks, i int) *store.SegmentFi
 // The previous link hash will be one of ten possible values.
 // The tags will be one of fifty possible combinations.
 func RandomFilterOffsetPrevLinkHashTags(b *testing.B, numLinks, i int) *store.SegmentFilter {
-	prevLinkHash, _ := types.NewBytes32FromString(fmt.Sprintf("000000000000000000000000000000000000000000000000000000000000000%d", i%10))
-	prevLinkHashStr := prevLinkHash.String()
+	prevLinkHash, _ := chainscript.NewLinkHashFromString(fmt.Sprintf("000000000000000000000000000000000000000000000000000000000000000%d", i%10))
+
 	return &store.SegmentFilter{
 		Pagination: store.Pagination{
 			Offset: rand.Int() % numLinks,
 			Limit:  store.DefaultLimit,
 		},
-		PrevLinkHash: &prevLinkHashStr,
+		PrevLinkHash: prevLinkHash,
 		Tags:         []string{fmt.Sprintf("%d", i%5), fmt.Sprintf("%d", i%10)},
 	}
 }

--- a/store/storetestcases/findsegments.go
+++ b/store/storetestcases/findsegments.go
@@ -251,10 +251,10 @@ func (f Factory) TestFindSegments(t *testing.T) {
 	t.Run("Supports filtering on link hashes", func(t *testing.T) {
 		ctx := context.Background()
 		slice, err := a.FindSegments(ctx, &store.SegmentFilter{
-			LinkHashes: []string{
-				linkHash4.String(),
-				chainscripttest.RandomHash().String(),
-				linkHash6.String(),
+			LinkHashes: []chainscript.LinkHash{
+				linkHash4,
+				chainscripttest.RandomHash(),
+				linkHash6,
 			},
 			Pagination: store.Pagination{
 				Limit: segmentsTotalCount,
@@ -266,9 +266,9 @@ func (f Factory) TestFindSegments(t *testing.T) {
 	t.Run("Supports filtering on link hash and process at the same time", func(t *testing.T) {
 		ctx := context.Background()
 		slice, err := a.FindSegments(ctx, &store.SegmentFilter{
-			LinkHashes: []string{
-				linkHash4.String(),
-				linkHash6.String(),
+			LinkHashes: []chainscript.LinkHash{
+				linkHash4,
+				linkHash6,
 			},
 			Process: "Foo",
 			Pagination: store.Pagination{
@@ -281,9 +281,9 @@ func (f Factory) TestFindSegments(t *testing.T) {
 	t.Run("Should return no results for unknown link hashes", func(t *testing.T) {
 		ctx := context.Background()
 		slice, err := a.FindSegments(ctx, &store.SegmentFilter{
-			LinkHashes: []string{
-				chainscripttest.RandomHash().String(),
-				chainscripttest.RandomHash().String(),
+			LinkHashes: []chainscript.LinkHash{
+				chainscripttest.RandomHash(),
+				chainscripttest.RandomHash(),
 			},
 			Pagination: store.Pagination{
 				Limit: segmentsTotalCount,
@@ -292,35 +292,33 @@ func (f Factory) TestFindSegments(t *testing.T) {
 		verifyResultsCount(t, err, slice, 0)
 	})
 
-	t.Run("Supports filtering for segments with empty previous link hash", func(t *testing.T) {
+	t.Run("Supports filtering for segments without parents", func(t *testing.T) {
 		ctx := context.Background()
 		slice, err := a.FindSegments(ctx, &store.SegmentFilter{
-			Pagination:   store.Pagination{Limit: segmentsTotalCount},
-			PrevLinkHash: &emptyPrevLinkHash,
+			Pagination:    store.Pagination{Limit: segmentsTotalCount},
+			WithoutParent: true,
 		})
 		verifyResultsCount(t, err, slice, 2)
 	})
 
 	t.Run("Supports filtering by previous link hash", func(t *testing.T) {
 		ctx := context.Background()
-		prevLinkHash := linkHash4.String()
 		slice, err := a.FindSegments(ctx, &store.SegmentFilter{
 			Pagination: store.Pagination{
 				Limit: segmentsTotalCount,
 			},
-			PrevLinkHash: &prevLinkHash,
+			PrevLinkHash: linkHash4,
 		})
 		verifyResultsCount(t, err, slice, 2)
 	})
 
 	t.Run("Supports filtering by previous link hash and tags at the same time", func(t *testing.T) {
 		ctx := context.Background()
-		prevLinkHash := linkHash4.String()
 		slice, err := a.FindSegments(ctx, &store.SegmentFilter{
 			Pagination: store.Pagination{
 				Limit: segmentsTotalCount,
 			},
-			PrevLinkHash: &prevLinkHash,
+			PrevLinkHash: linkHash4,
 			Tags:         []string{"tag1"},
 		})
 		verifyResultsCount(t, err, slice, 1)
@@ -328,12 +326,11 @@ func (f Factory) TestFindSegments(t *testing.T) {
 
 	t.Run("Supports filtering by previous link hash and tags at the same time", func(t *testing.T) {
 		ctx := context.Background()
-		prevLinkHash := linkHash4.String()
 		slice, err := a.FindSegments(ctx, &store.SegmentFilter{
 			Pagination: store.Pagination{
 				Limit: segmentsTotalCount,
 			},
-			PrevLinkHash: &prevLinkHash,
+			PrevLinkHash: linkHash4,
 			MapIDs:       []string{"map1", "map2"},
 		})
 		verifyResultsCount(t, err, slice, 1)
@@ -341,12 +338,11 @@ func (f Factory) TestFindSegments(t *testing.T) {
 
 	t.Run("Returns no result when filtering on good previous link hash but invalid map ID", func(t *testing.T) {
 		ctx := context.Background()
-		prevLinkHash := linkHash4.String()
 		slice, err := a.FindSegments(ctx, &store.SegmentFilter{
 			Pagination: store.Pagination{
 				Limit: segmentsTotalCount,
 			},
-			PrevLinkHash: &prevLinkHash,
+			PrevLinkHash: linkHash4,
 			MapIDs:       []string{"map2"},
 		})
 		verifyResultsCount(t, err, slice, 0)
@@ -354,12 +350,12 @@ func (f Factory) TestFindSegments(t *testing.T) {
 
 	t.Run("Returns no result for previous link hash not found", func(t *testing.T) {
 		ctx := context.Background()
-		notFoundPrevLinkHash := chainscripttest.RandomHash().String()
+		notFoundPrevLinkHash := chainscripttest.RandomHash()
 		slice, err := a.FindSegments(ctx, &store.SegmentFilter{
 			Pagination: store.Pagination{
 				Limit: segmentsTotalCount,
 			},
-			PrevLinkHash: &notFoundPrevLinkHash,
+			PrevLinkHash: notFoundPrevLinkHash,
 		})
 		verifyResultsCount(t, err, slice, 0)
 	})
@@ -403,9 +399,7 @@ func (f Factory) TestFindSegments(t *testing.T) {
 			Pagination: store.Pagination{
 				Limit: segmentsTotalCount,
 			},
-			LinkHashes: []string{
-				linkHash4.String(),
-			},
+			LinkHashes: []chainscript.LinkHash{linkHash4},
 		})
 		verifyResultsCount(t, err, got, 1)
 		assert.True(t, len(got.Segments[0].Meta.Evidences) >= 4)

--- a/store/storetesting/mockadapter_test.go
+++ b/store/storetesting/mockadapter_test.go
@@ -100,8 +100,9 @@ func TestMockAdapter_FindSegments(t *testing.T) {
 			TotalCount: 1,
 		}, nil
 	}
-	prevLinkHash := chainscripttest.RandomHash().String()
-	f := store.SegmentFilter{PrevLinkHash: &prevLinkHash}
+
+	prevLinkHash := chainscripttest.RandomHash()
+	f := store.SegmentFilter{PrevLinkHash: prevLinkHash}
 	s1, err := a.FindSegments(context.Background(), &f)
 	require.NoError(t, err)
 

--- a/tmpop/tmpoptestcases/query.go
+++ b/tmpop/tmpoptestcases/query.go
@@ -84,13 +84,12 @@ func (f Factory) TestQuery(t *testing.T) {
 	})
 
 	t.Run("FindSegments()", func(t *testing.T) {
-		wantedPrevLinkHashStr := link2.PrevLinkHash().String()
 		args := &store.SegmentFilter{
 			Pagination: store.Pagination{
 				Limit: store.DefaultLimit,
 			},
 			MapIDs:       []string{link2.Meta.MapId},
-			PrevLinkHash: &wantedPrevLinkHashStr,
+			PrevLinkHash: link2.PrevLinkHash(),
 			Tags:         link2.Meta.Tags,
 		}
 		gots := types.PaginatedSegments{}


### PR DESCRIPTION
SegmentFilter now uses chainscript.LinkHash for consistency.
Note that the APIs that use URL query parameters still expect hex strings (in a URL it makes sense to use a byte encoding, and hex is easy to reason with and visual).
A new field `WithoutParent` has been added to filter for links that don't have a parent (instead of the ugly hack of distinguishing nil and "").
Fixed most of the context.TODO() in elasticsearchstore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/go-indigocore/440)
<!-- Reviewable:end -->
